### PR TITLE
VZA | Update button styles/text and add pagination below the "Available Assignments" view

### DIFF
--- a/code/vza/vza.css
+++ b/code/vza/vza.css
@@ -1,10 +1,10 @@
 .block {
   display: block;
-  width: 20%;
   border: none;
-  background-color: #367db7;
+  border-radius: 0.2em;
+  background-color: #00396d;
   color: white;
-  padding: 5px 5px;
+  padding: 10px 45px;
   font-size: 20px;
   cursor: pointer;
   text-align: center;
@@ -28,4 +28,10 @@
 
 .assignments-table {
   overflow: visible;
+  /* Add some space between table and pagination controls below */
+  margin-bottom: 10.5px;
+}
+
+.my-shift-button > span.icon > i {
+  color: #af3c3c;
 }

--- a/code/vza/vza.js
+++ b/code/vza/vza.js
@@ -2,6 +2,7 @@ $(document).on("knack-view-render.any", function (event, view, data) {
   $("a.kn-view-asset").html("Attachment");
 });
 
+// Sign Up page
 // Hide Knack generated "Available Assignments" table, create and add table that condenses
 // sign up for multiple officer_assignments into one button
 $(document).on("knack-view-render.view_466", function (event, view, data) {
@@ -802,6 +803,8 @@ $(document).on("knack-view-render.view_466", function (event, view, data) {
     });
 });
 
+// Assignment Details page
+// Update start button text
 $(document).on("knack-view-render.view_449", function (event, view, data) {
   $("#view_449 button strong")[0].innerText = " Start Assignment";
 });

--- a/code/vza/vza.js
+++ b/code/vza/vza.js
@@ -608,9 +608,9 @@ $(document).on("knack-view-render.view_466", function (event, view, data) {
   }
 
   // Add button handler to associate officer assignment records with logged in user
-  function addPaginationClickHandlers(prevId, nextId) {
-    var prev = $(`#${prevId}`);
-    var next = $(`#${nextId}`);
+  function addPaginationClickHandlers(prevClass, nextClass) {
+    var prev = $(`.${prevClass}`);
+    var next = $(`.${nextClass}`);
 
     prev.click(function () {
       if (currentPage === 1) {
@@ -681,10 +681,10 @@ $(document).on("knack-view-render.view_466", function (event, view, data) {
         <div class="kn-pagination level-right">
           <div class="kn-total-pages">${currentPage} of ${numberOfPages}</div>
           <div class="pagination-arrows">
-            <span class="icon" id="prev-arrow">
+            <span class="icon prev-arrow">
               <i class="fa fa-chevron-left"></i>
             </span>
-            <span class="icon" id="next-arrow">
+            <span class="icon next-arrow">
               <i class="fa fa-chevron-right"></i>
             </span>
           </div>
@@ -692,6 +692,7 @@ $(document).on("knack-view-render.view_466", function (event, view, data) {
       </div>`;
 
     $(".assignments-table").before(paginationControls);
+    $(".assignments-table").after(paginationControls);
     addPaginationClickHandlers("prev-arrow", "next-arrow");
   }
 
@@ -797,4 +798,11 @@ $(document).on("knack-view-render.view_466", function (event, view, data) {
     .ready(function () {
       requestRecords(filters.all);
     });
+});
+
+$(document).on("knack-view-render.view_448", function (event, view, data) {
+  // #view_449 > section > div > div > div > div > div > div > span > a > h2 > button > strong
+  console.log(data);
+  if (data) {
+  }
 });

--- a/code/vza/vza.js
+++ b/code/vza/vza.js
@@ -114,6 +114,8 @@ $(document).on("knack-view-render.view_466", function (event, view, data) {
   // Setup pagination
   function initializePagination(records) {
     currentPage = 1;
+    currentRangeStart = 1;
+    currentRangeEnd = currentPage - 1 + recordsPerPage;
     numberOfPages = Math.ceil(records.length / recordsPerPage);
 
     var initialPageRecords = records.slice(0, recordsPerPage);

--- a/code/vza/vza.js
+++ b/code/vza/vza.js
@@ -802,9 +802,6 @@ $(document).on("knack-view-render.view_466", function (event, view, data) {
     });
 });
 
-$(document).on("knack-view-render.view_448", function (event, view, data) {
-  // #view_449 > section > div > div > div > div > div > div > span > a > h2 > button > strong
-  console.log(data);
-  if (data) {
-  }
+$(document).on("knack-view-render.view_449", function (event, view, data) {
+  $("#view_449 button strong")[0].innerText = " Start Assignment";
 });


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/3929
Closes https://github.com/cityofaustin/atd-data-tech/issues/3922
Closes https://github.com/cityofaustin/atd-data-tech/issues/3921

This PR adds the pagination controls below the "Available Assignments" table in the "Sign Up" view in addition to the pagination controls before the table to make it clear that more records exist on mobile. It also updates the cancel button icon color and the styles and text in the start button of the "Assignment Details" view.

I also patched a small bug where the start and end record ranges were not updating properly after using the time filters on a page beyond page 1.

### Pagination controls below table
<img width="435" alt="Screen Shot 2020-09-11 at 3 01 29 PM" src="https://user-images.githubusercontent.com/37249039/92968897-8767cd80-f441-11ea-8cd1-426bcfcaf88b.png">

### Updated cancel icon color
<img width="435" alt="Screen Shot 2020-09-11 at 3 01 09 PM" src="https://user-images.githubusercontent.com/37249039/92968913-8e8edb80-f441-11ea-8c18-97b15ff152fb.png">

### Updated assignment start button styles
#### Before
<img width="435" alt="Screen Shot before" src="https://user-images.githubusercontent.com/1463708/92562945-64b89780-f23c-11ea-974b-93a714004a25.png" />

#### After
<img width="435" alt="Screen Shot 2020-09-11 at 3 00 49 PM" src="https://user-images.githubusercontent.com/37249039/92969062-d31a7700-f441-11ea-8434-231eb3ef420f.png">

