### PR TITLE
VZA | Implement simplified assignment cancellation

### DIFF
--- a/code/vza/README.md
+++ b/code/vza/README.md
@@ -22,6 +22,7 @@
 - Remove From My Assignments Date and Time
 - Reason for Cancellation
 - Unassigned Officer
+- Status
 - Send email action **(this column is setup in Step 4)**
 
 ![API view columns](images/api_view_columns.png)

--- a/code/vza/vza.css
+++ b/code/vza/vza.css
@@ -1,10 +1,10 @@
 .block {
   display: block;
-  width: 20%;
   border: none;
-  background-color: #367db7;
+  border-radius: 0.2em;
+  background-color: #00396d;
   color: white;
-  padding: 5px 5px;
+  padding: 10px 45px;
   font-size: 20px;
   cursor: pointer;
   text-align: center;
@@ -28,4 +28,10 @@
 
 .assignments-table {
   overflow: visible;
+  /* Add some space between table and pagination controls below */
+  margin-bottom: 10.5px;
+}
+
+.my-shift-button > span.icon > i {
+  color: #af3c3c;
 }

--- a/code/vza/vza.js
+++ b/code/vza/vza.js
@@ -222,6 +222,9 @@ function requestRecords(filterConfig, view, tableConfig) {
   // Remove Knack generated table that we are replacing and request records
   removeKnackTable(view);
 
+  // Calculate number of columns to set colspan in
+  var numberOfColumns = Object.keys(tableConfig.columns).length;
+
   // Request officer_assignment records
   $.ajax({
     url: url,
@@ -246,7 +249,9 @@ function requestRecords(filterConfig, view, tableConfig) {
       recordsInPage = initializePagination(completeRecords);
       buildAndAppendShiftSection(recordsInPage);
       prependShiftTableWithPagination();
-      prependPaginationWithTimeFilters();
+      if (tableConfig.addTimeFilters) {
+        prependPaginationWithTimeFilters();
+      }
       addOpenShiftButtonClickHandlers();
       addCancelMyShiftButtonClickHandlers();
 
@@ -268,9 +273,9 @@ function requestRecords(filterConfig, view, tableConfig) {
       records.forEach(function (shiftRecords) {
         shiftsHTML += `
           <tr class="kn-table-group kn-group-level-1">
-            <td class="shift-header" colspan="4">${
-              shiftRecords[0][fields.officerShiftField]
-            }</td>
+            <td class="shift-header" colspan="${numberOfColumns}">${
+          shiftRecords[0][fields.officerShiftField]
+        }</td>
           </tr>`;
 
         // Condense each set of officer_assignments that make up a shift together
@@ -359,7 +364,7 @@ function requestRecords(filterConfig, view, tableConfig) {
         // Add sign up buttons
         shiftsHTML += `
           <tr>
-            <td style="padding-top: 16px;" colspan="4">
+            <td style="padding-top: 16px;" colspan="${numberOfColumns}">
           `;
 
         function setButtonStatus(
@@ -498,81 +503,81 @@ function requestRecords(filterConfig, view, tableConfig) {
     thisButtonIcon
   ) {
     var cancellationForm = `
-  <div
-  id="kn-modal-bg-0"
-  class="kn-modal-bg cancellation-modal"
-  style="top: 0px; z-index: 2000; display: block"
-  >
-    <div class="kn-modal default" style="display: block">
-      <header class="modal-card-head">
-        <h1 class="modal-card-title">Remove From Today's Assignments</h1>
-        <button class="delete close-cancellation-modal"></button>
-      </header>
-      <section class="modal-card-body kn-page-modal" id="kn-page-modal-0">
-        <div class="kn-scene kn-container" id="kn-scene_236">
-          <div class="kn-form kn-view view_484" id="view_484">
-            <form id="cancellation-form">
-              <ul class="kn-form-group columns kn-form-group-1">
-                <li class="kn-form-col column is-constrained">
-                  <div
-                    class="kn-input kn-input-short_text control"
-                    id="kn-input-field_671"
-                    data-input-id="field_671"
-                  >
-                    <label for="field_671" class="label kn-label"
-                      ><span>Reason for Cancellation</span></label
+    <div
+    id="kn-modal-bg-0"
+    class="kn-modal-bg cancellation-modal"
+    style="top: 0px; z-index: 2000; display: block"
+    >
+      <div class="kn-modal default" style="display: block">
+        <header class="modal-card-head">
+          <h1 class="modal-card-title">Remove From Today's Assignments</h1>
+          <button class="delete close-cancellation-modal"></button>
+        </header>
+        <section class="modal-card-body kn-page-modal" id="kn-page-modal-0">
+          <div class="kn-scene kn-container" id="kn-scene_236">
+            <div class="kn-form kn-view view_484" id="view_484">
+              <form id="cancellation-form">
+                <ul class="kn-form-group columns kn-form-group-1">
+                  <li class="kn-form-col column is-constrained">
+                    <div
+                      class="kn-input kn-input-short_text control"
+                      id="kn-input-field_671"
+                      data-input-id="field_671"
                     >
-                    <div class="control">
-                      <input
-                        class="input"
-                        id="field_671"
-                        name="field_671"
-                        type="text"
-                        value=""
-                      />
+                      <label for="field_671" class="label kn-label"
+                        ><span>Reason for Cancellation</span></label
+                      >
+                      <div class="control">
+                        <input
+                          class="input"
+                          id="field_671"
+                          name="field_671"
+                          type="text"
+                          value=""
+                        />
+                      </div>
+                      <p class="kn-instructions" style="display: none"></p>
                     </div>
-                    <p class="kn-instructions" style="display: none"></p>
-                  </div>
-                  <div
-                    class="kn-input kn-input-boolean control"
-                    id="kn-input-field_711"
-                    data-input-id="field_711"
-                  >
-                    <label for="field_711" class="label kn-label"
-                      ><span>Remove From My Assignments</span></label
+                    <div
+                      class="kn-input kn-input-boolean control"
+                      id="kn-input-field_711"
+                      data-input-id="field_711"
                     >
-                    <div class="control">
-                      <label class="option checkbox"
-                        ><input
-                          type="checkbox"
-                          name="field_711"
-                          value="Yes"
-                        />&nbsp;I have read the SEU Cancellation Policy and
-                        understand that by cancelling this assignment with less
-                        than 48 hours notice I am responsible for finding another
-                        Officer to work the shift or risk losing eligibility for
-                        SEU assignments.</label
+                      <label for="field_711" class="label kn-label"
+                        ><span>Remove From My Assignments</span></label
                       >
+                      <div class="control">
+                        <label class="option checkbox"
+                          ><input
+                            type="checkbox"
+                            name="field_711"
+                            value="Yes"
+                          />&nbsp;I have read the SEU Cancellation Policy and
+                          understand that by cancelling this assignment with less
+                          than 48 hours notice I am responsible for finding another
+                          Officer to work the shift or risk losing eligibility for
+                          SEU assignments.</label
+                        >
+                      </div>
+                      <p class="kn-instructions">
+                        <a
+                          href="https://docs.google.com/document/d/1cODXt1FuJVHAmiSg23hdcQDrfcFaiKhUmVOiFxgJ-4g/edit?usp=sharing"
+                          >Cancellation Policy</a
+                        >
+                      </p>
                     </div>
-                    <p class="kn-instructions">
-                      <a
-                        href="https://docs.google.com/document/d/1cODXt1FuJVHAmiSg23hdcQDrfcFaiKhUmVOiFxgJ-4g/edit?usp=sharing"
-                        >Cancellation Policy</a
-                      >
-                    </p>
-                  </div>
-                </li>
-              </ul>
-              <div class="kn-submit">    
-                <button class="kn-button is-primary" type="submit">Submit</button>
-              </div>
-            </form>
+                  </li>
+                </ul>
+                <div class="kn-submit">    
+                  <button class="kn-button is-primary" type="submit">Submit</button>
+                </div>
+              </form>
+            </div>
           </div>
-        </div>
-      </section>
+        </section>
+      </div>
     </div>
-  </div>
-  `;
+    `;
 
     // Append cancellation modal and handle form submit
     $(".kn-content").append(cancellationForm);
@@ -725,28 +730,28 @@ function requestRecords(filterConfig, view, tableConfig) {
     }
 
     var paginationControls = `
-  <div class="level pagination-controls" style="margin-bottom: .75em;">
-    <div class="level-left">
-      <div class="kn-entries-summary" style="margin-right: .5em;">
-        <span class="light">Showing</span> ${currentRangeStart}-${Math.min(
+    <div class="level pagination-controls" style="margin-bottom: .75em;">
+      <div class="level-left">
+        <div class="kn-entries-summary" style="margin-right: .5em;">
+          <span class="light">Showing</span> ${currentRangeStart}-${Math.min(
       currentRangeEnd,
       completeRecords.length
     )}
-        <span class="light">of</span> ${completeRecords.length}
+          <span class="light">of</span> ${completeRecords.length}
+        </div>
       </div>
-    </div>
-    <div class="kn-pagination level-right">
-      <div class="kn-total-pages">${currentPage} of ${numberOfPages}</div>
-      <div class="pagination-arrows">
-        <span class="icon prev-arrow">
-          <i class="fa fa-chevron-left"></i>
-        </span>
-        <span class="icon next-arrow">
-          <i class="fa fa-chevron-right"></i>
-        </span>
+      <div class="kn-pagination level-right">
+        <div class="kn-total-pages">${currentPage} of ${numberOfPages}</div>
+        <div class="pagination-arrows">
+          <span class="icon prev-arrow">
+            <i class="fa fa-chevron-left"></i>
+          </span>
+          <span class="icon next-arrow">
+            <i class="fa fa-chevron-right"></i>
+          </span>
+        </div>
       </div>
-    </div>
-  </div>`;
+    </div>`;
 
     $("#" + view + " .assignments-table").before(paginationControls);
     $("#" + view + " .assignments-table").after(paginationControls);
@@ -760,25 +765,25 @@ function requestRecords(filterConfig, view, tableConfig) {
     }
 
     var filterMenu = `
-  <div class="js-filter-menu tabs is-toggle is-flush">
-    <ul id="time-filter-buttons">
-      <li class="is-active" id="all">
-        <a>
-          <span>All</span>
-        </a>
-      </li>
-      <li id="week">
-        <a>
-          <span>Next Week</span>
-        </a>
-      </li>
-      <li id="month">
-        <a>
-          <span>Next Month</span>
-        </a>
+    <div class="js-filter-menu tabs is-toggle is-flush">
+      <ul id="time-filter-buttons">
+        <li class="is-active" id="all">
+          <a>
+            <span>All</span>
+          </a>
         </li>
-     </ul>
-  </div>`;
+        <li id="week">
+          <a>
+            <span>Next Week</span>
+          </a>
+        </li>
+        <li id="month">
+          <a>
+            <span>Next Month</span>
+          </a>
+          </li>
+      </ul>
+    </div>`;
 
     $("#" + view + " .pagination-controls")
       .before(filterMenu)
@@ -789,7 +794,7 @@ function requestRecords(filterConfig, view, tableConfig) {
             // Request records with matching time filter on click
             $(this).click(function () {
               var clickedFilterButtonId = $(this).attr("id");
-              requestRecords(filters[clickedFilterButtonId], view);
+              requestRecords(filters[clickedFilterButtonId], view, tableConfig);
 
               // Add/remove active button status
               $("#" + view + " #time-filter-buttons")
@@ -813,10 +818,10 @@ function requestRecords(filterConfig, view, tableConfig) {
     }
 
     var noRecordsRow = `
-  <tr class="kn-table-group kn-group-level-1" id="no-records-msg">
-    <td colspan="4">No assignments available</td>
-  </tr>  
-`;
+    <tr class="kn-table-group kn-group-level-1" id="no-records-msg">
+      <td colspan="${numberOfColumns}">No assignments available</td>
+    </tr>  
+    `;
 
     $("." + view + ".shift-table-body").append(noRecordsRow);
   }
@@ -828,6 +833,7 @@ function requestRecords(filterConfig, view, tableConfig) {
 $(document).on("knack-view-render.view_466", function (event, view, data) {
   var tableConfig = {
     columns: {
+      // Header Title: Getter() for data in record
       Time: function (record) {
         return record[fields.timeField];
       },
@@ -837,7 +843,8 @@ $(document).on("knack-view-render.view_466", function (event, view, data) {
       Location: function (record) {
         return record[fields.locationFieldRaw][0].identifier.split(" - ")[2];
       }
-    }
+    },
+    addTimeFilters: true
   };
 
   var recordsTable = createRecordsTable(view.key, tableConfig);
@@ -851,32 +858,74 @@ $(document).on("knack-view-render.view_466", function (event, view, data) {
 });
 
 // #### My Assignments page ####
-// Hide Knack generated "Available Assignments" table, create and add table that condenses
-// sign up for multiple officer_assignments into one button
+// Hide Knack generated "Today's Assignments" and "Future Assignments" table, create and add tables that condense
+// cancellation for multiple officer_assignments into one button
+var tableConfig = {
+  columns: {
+    Status: function (record) {
+      return record[fields.assignmentStatus];
+    },
+    Time: function (record) {
+      return record[fields.timeField];
+    },
+    Sector: function (record) {
+      return record[fields.locationFieldRaw][0].identifier.split(" - ")[0];
+    },
+    Location: function (record) {
+      return record[fields.locationFieldRaw][0].identifier.split(" - ")[2];
+    }
+  },
+  addTimeFilters: false
+};
+
+function addRecordLinkToTableConfig(event, view, config) {
+  // var location = event.currentTarget.location;
+  var slug = view.scene.slug;
+  // var recordLinkUrl = location.origin + location.pathname + "#" + slug;
+
+  function createFolderIconLink(record) {
+    return `
+    <a href="#${slug}/assignment-details/${record.id}" 
+    class="kn-link kn-link-page" address="true" style="text-align: center; ">
+      <span class="level is-compact">
+        <span class="icon is-left">
+          <i class="fa fa-folder-open-o"></i>
+        </span>
+      </span>
+    </a>
+    `;
+  }
+
+  return {
+    ...config,
+    columns: { Details: createFolderIconLink, ...config.columns }
+  };
+}
+
 $(document).on("knack-view-render.view_447", function (event, view, data) {
-  var recordsTable = createRecordsTable(view.key, tableConfig);
+  var updatedTableConfig = addRecordLinkToTableConfig(event, view, tableConfig);
+  var recordsTable = createRecordsTable(view.key, updatedTableConfig);
+
   // Append table, then request records and append shifts to table body
   $("#view_447" + "> div.view-header")
     .after(recordsTable)
     .ready(function () {
-      requestRecords(filters.today, view.key, tableConfig);
+      requestRecords(filters.today, view.key, updatedTableConfig);
     });
   // TODO: Link to My Assignment Details
-  // TODO: No time filter buttons
   // TODO: Don't toggle between cancel and sign up buttons
-  // TODO: Add columns needed to configs
 });
 
 $(document).on("knack-view-render.view_439", function (event, view, data) {
-  var recordsTable = createRecordsTable(view.key, tableConfig);
+  var updatedTableConfig = addRecordLinkToTableConfig(event, view, tableConfig);
+  var recordsTable = createRecordsTable(view.key, updatedTableConfig);
+
   // Append table, then request records and append shifts to table body
   $("#" + view.key + "> div.view-header")
     .after(recordsTable)
     .ready(function () {
-      requestRecords(filters.future, view.key, tableConfig);
+      requestRecords(filters.future, view.key, updatedTableConfig);
     });
   // TODO: Link to My Assignment Details
-  // TODO: No time filter buttons
   // TODO: Don't toggle between cancel and sign up buttons
-  // TODO: Add columns needed to configs
 });

--- a/code/vza/vza.js
+++ b/code/vza/vza.js
@@ -623,10 +623,12 @@ function requestRecords(filterConfig, view, tableConfig) {
               .addClass("fa-plus-square");
             addOpenShiftButtonClickHandlers();
 
-            // Update cached record
-            var thisRecord = findRecordById(recordId);
-            thisRecord[fields.assignedOfficerFieldRaw][0].id =
-              appSpecifics.noOfficerAssignedId;
+            // Update cached record based if reverting to .open-shift-button button
+            if (!tableConfig.isCancelOnly) {
+              var thisRecord = findRecordById(recordId);
+              thisRecord[fields.assignedOfficerFieldRaw][0].id =
+                appSpecifics.noOfficerAssignedId;
+            }
 
             // Remove modal and stop spinner
             $("#kn-modal-bg-0").remove();
@@ -634,6 +636,11 @@ function requestRecords(filterConfig, view, tableConfig) {
           }
         });
       });
+
+      // If only cancelling, reload table to refresh user's assignments
+      if (tableConfig.isCancelOnly) {
+        requestRecords(filterConfig, view, tableConfig);
+      }
     });
 
     // Add click handler to close modal (X) button
@@ -661,8 +668,7 @@ function requestRecords(filterConfig, view, tableConfig) {
           recordIdsString,
           buttonNumber,
           thisButton,
-          thisButtonIcon,
-          view
+          thisButtonIcon
         );
       });
     });
@@ -844,7 +850,8 @@ $(document).on("knack-view-render.view_466", function (event, view, data) {
         return record[fields.locationFieldRaw][0].identifier.split(" - ")[2];
       }
     },
-    addTimeFilters: true
+    addTimeFilters: true,
+    isCancelOnly: false
   };
 
   var recordsTable = createRecordsTable(view.key, tableConfig);
@@ -875,13 +882,12 @@ var tableConfig = {
       return record[fields.locationFieldRaw][0].identifier.split(" - ")[2];
     }
   },
-  addTimeFilters: false
+  addTimeFilters: false,
+  isCancelOnly: true
 };
 
-function addRecordLinkToTableConfig(event, view, config) {
-  // var location = event.currentTarget.location;
+function addRecordLinkToTableConfig(view, config) {
   var slug = view.scene.slug;
-  // var recordLinkUrl = location.origin + location.pathname + "#" + slug;
 
   function createFolderIconLink(record) {
     return `
@@ -903,7 +909,7 @@ function addRecordLinkToTableConfig(event, view, config) {
 }
 
 $(document).on("knack-view-render.view_447", function (event, view, data) {
-  var updatedTableConfig = addRecordLinkToTableConfig(event, view, tableConfig);
+  var updatedTableConfig = addRecordLinkToTableConfig(view, tableConfig);
   var recordsTable = createRecordsTable(view.key, updatedTableConfig);
 
   // Append table, then request records and append shifts to table body
@@ -912,12 +918,10 @@ $(document).on("knack-view-render.view_447", function (event, view, data) {
     .ready(function () {
       requestRecords(filters.today, view.key, updatedTableConfig);
     });
-  // TODO: Link to My Assignment Details
-  // TODO: Don't toggle between cancel and sign up buttons
 });
 
 $(document).on("knack-view-render.view_439", function (event, view, data) {
-  var updatedTableConfig = addRecordLinkToTableConfig(event, view, tableConfig);
+  var updatedTableConfig = addRecordLinkToTableConfig(view, tableConfig);
   var recordsTable = createRecordsTable(view.key, updatedTableConfig);
 
   // Append table, then request records and append shifts to table body
@@ -926,6 +930,4 @@ $(document).on("knack-view-render.view_439", function (event, view, data) {
     .ready(function () {
       requestRecords(filters.future, view.key, updatedTableConfig);
     });
-  // TODO: Link to My Assignment Details
-  // TODO: Don't toggle between cancel and sign up buttons
 });

--- a/code/vza/vza.js
+++ b/code/vza/vza.js
@@ -2,6 +2,7 @@ $(document).on("knack-view-render.any", function (event, view, data) {
   $("a.kn-view-asset").html("Attachment");
 });
 
+// Sign Up page
 // Hide Knack generated "Available Assignments" table, create and add table that condenses
 // sign up for multiple officer_assignments into one button
 $(document).on("knack-view-render.view_466", function (event, view, data) {
@@ -802,6 +803,8 @@ $(document).on("knack-view-render.view_466", function (event, view, data) {
     });
 });
 
+// Assignment Details page
+// Update start button text
 $(document).on("knack-view-render.view_449", function (event, view, data) {
   $("#view_449 button strong")[0].innerText = " Start Assignment";
 });

--- a/code/vza/vza.js
+++ b/code/vza/vza.js
@@ -608,9 +608,9 @@ $(document).on("knack-view-render.view_466", function (event, view, data) {
   }
 
   // Add button handler to associate officer assignment records with logged in user
-  function addPaginationClickHandlers(prevId, nextId) {
-    var prev = $(`#${prevId}`);
-    var next = $(`#${nextId}`);
+  function addPaginationClickHandlers(prevClass, nextClass) {
+    var prev = $(`.${prevClass}`);
+    var next = $(`.${nextClass}`);
 
     prev.click(function () {
       if (currentPage === 1) {
@@ -681,10 +681,10 @@ $(document).on("knack-view-render.view_466", function (event, view, data) {
         <div class="kn-pagination level-right">
           <div class="kn-total-pages">${currentPage} of ${numberOfPages}</div>
           <div class="pagination-arrows">
-            <span class="icon" id="prev-arrow">
+            <span class="icon prev-arrow">
               <i class="fa fa-chevron-left"></i>
             </span>
-            <span class="icon" id="next-arrow">
+            <span class="icon next-arrow">
               <i class="fa fa-chevron-right"></i>
             </span>
           </div>
@@ -692,6 +692,7 @@ $(document).on("knack-view-render.view_466", function (event, view, data) {
       </div>`;
 
     $(".assignments-table").before(paginationControls);
+    $(".assignments-table").after(paginationControls);
     addPaginationClickHandlers("prev-arrow", "next-arrow");
   }
 
@@ -797,4 +798,11 @@ $(document).on("knack-view-render.view_466", function (event, view, data) {
     .ready(function () {
       requestRecords(filters.all);
     });
+});
+
+$(document).on("knack-view-render.view_448", function (event, view, data) {
+  // #view_449 > section > div > div > div > div > div > div > span > a > h2 > button > strong
+  console.log(data);
+  if (data) {
+  }
 });

--- a/code/vza/vza.js
+++ b/code/vza/vza.js
@@ -867,25 +867,8 @@ $(document).on("knack-view-render.view_466", function (event, view, data) {
 // #### My Assignments page ####
 // Hide Knack generated "Today's Assignments" and "Future Assignments" table, create and add tables that condense
 // cancellation for multiple officer_assignments into one button
-var tableConfig = {
-  columns: {
-    Status: function (record) {
-      return record[fields.assignmentStatus];
-    },
-    Time: function (record) {
-      return record[fields.timeField];
-    },
-    Sector: function (record) {
-      return record[fields.locationFieldRaw][0].identifier.split(" - ")[0];
-    },
-    Location: function (record) {
-      return record[fields.locationFieldRaw][0].identifier.split(" - ")[2];
-    }
-  },
-  addTimeFilters: false,
-  isCancelOnly: true
-};
 
+// Helper to create folder icon link in custom table data cells
 function addRecordLinkToTableConfig(view, config) {
   var slug = view.scene.slug;
 
@@ -909,6 +892,25 @@ function addRecordLinkToTableConfig(view, config) {
 }
 
 $(document).on("knack-view-render.view_447", function (event, view, data) {
+  var tableConfig = {
+    columns: {
+      Status: function (record) {
+        return record[fields.assignmentStatus];
+      },
+      Time: function (record) {
+        return record[fields.timeField];
+      },
+      Sector: function (record) {
+        return record[fields.locationFieldRaw][0].identifier.split(" - ")[0];
+      },
+      Location: function (record) {
+        return record[fields.locationFieldRaw][0].identifier.split(" - ")[2];
+      }
+    },
+    addTimeFilters: false,
+    isCancelOnly: true
+  };
+
   var updatedTableConfig = addRecordLinkToTableConfig(view, tableConfig);
   var recordsTable = createRecordsTable(view.key, updatedTableConfig);
 
@@ -921,13 +923,28 @@ $(document).on("knack-view-render.view_447", function (event, view, data) {
 });
 
 $(document).on("knack-view-render.view_439", function (event, view, data) {
-  var updatedTableConfig = addRecordLinkToTableConfig(view, tableConfig);
-  var recordsTable = createRecordsTable(view.key, updatedTableConfig);
+  var tableConfig = {
+    columns: {
+      Time: function (record) {
+        return record[fields.timeField];
+      },
+      Sector: function (record) {
+        return record[fields.locationFieldRaw][0].identifier.split(" - ")[0];
+      },
+      Location: function (record) {
+        return record[fields.locationFieldRaw][0].identifier.split(" - ")[2];
+      }
+    },
+    addTimeFilters: false,
+    isCancelOnly: true
+  };
+
+  var recordsTable = createRecordsTable(view.key, tableConfig);
 
   // Append table, then request records and append shifts to table body
   $("#" + view.key + "> div.view-header")
     .after(recordsTable)
     .ready(function () {
-      requestRecords(filters.future, view.key, updatedTableConfig);
+      requestRecords(filters.future, view.key, tableConfig);
     });
 });

--- a/code/vza/vza.js
+++ b/code/vza/vza.js
@@ -2,809 +2,806 @@ $(document).on("knack-view-render.any", function (event, view, data) {
   $("a.kn-view-asset").html("Attachment");
 });
 
-// Sign Up page
-// Hide Knack generated "Available Assignments" table, create and add table that condenses
-// sign up for multiple officer_assignments into one button
-$(document).on("knack-view-render.view_466", function (event, view, data) {
-  // Must be updated/checked when moving this code to a new instance
-  var appSpecifics = {
-    knackAppId: "5dc2ec50bbcb360016e338e1",
-    apiTableScene: "scene_238", // Officer assignments table API scene
-    apiTableView: "view_487", // Officer assignments table API view
-    availableAssignmentsView: "view_466", // Where to insert new table
-    noOfficerAssignedId: "5ebef4d0682bfc0015c9e0f4" // For conditional styles based on officer assigned
-  };
+// #### Officer Assignments (batch officer_assignments workflows) ####
+// #### Sign up page and My Assignments page ####
 
-  // officer_assignment object fields
-  var fields = {
-    dateField: "field_154",
-    timeField: "field_139",
-    locationFieldRaw: "field_656_raw",
-    assignedOfficerFieldRaw: "field_704_raw",
-    assignedOfficerField: "field_704",
-    officerShiftField: "field_724",
-    assignmentDateTimeField: "field_133",
-    unassignedOfficerField: "field_669",
-    addToMyAssignmentsField: "field_663",
-    dateTimeOfCancellationField: "field_712"
-  };
+// ### App Specific Attributes ###
+// Must be updated/checked when moving this code to a new instance
+var appSpecifics = {
+  knackAppId: "5dc2ec50bbcb360016e338e1",
+  apiTableScene: "scene_238", // Officer assignments table API scene
+  apiTableView: "view_487", // Officer assignments table API view
+  availableAssignmentsView: "view_466", // Where to insert new table
+  noOfficerAssignedId: "5ebef4d0682bfc0015c9e0f4" // For conditional styles based on officer assigned
+};
 
-  // Cache all officer_assignments to traverse with pagination
-  var completeRecords = null;
+// officer_assignment object fields
+var fields = {
+  dateField: "field_154",
+  timeField: "field_139",
+  locationFieldRaw: "field_656_raw",
+  assignedOfficerFieldRaw: "field_704_raw",
+  assignedOfficerField: "field_704",
+  officerShiftField: "field_724",
+  assignmentDateTimeField: "field_133",
+  unassignedOfficerField: "field_669",
+  addToMyAssignmentsField: "field_663",
+  dateTimeOfCancellationField: "field_712"
+};
 
-  // Cache records to display on each page
-  var recordsInPage = null;
+// Shared code
+// Cache all officer_assignments to traverse with pagination
+var completeRecords = null;
 
-  // Keep track of pagination details
-  var currentPage = 1;
-  var recordsPerPage = 10;
-  var numberOfPages = null;
-  var currentRangeStart = 1;
-  var currentRangeEnd = currentPage - 1 + recordsPerPage;
+// Cache records to display on each page
+var recordsInPage = null;
 
-  // Filter for records for assignments time windows
-  var filters = {
-    all: [
-      {
-        field: fields.dateField,
-        operator: "is today or after"
-      },
-      {
-        field: fields.assignmentDateTimeField,
-        operator: "is not blank"
-      }
-    ],
-    week: [
-      {
-        value: "",
-        text: "Next Week",
-        operator: "is during the next",
-        field: fields.dateField,
-        type: "weeks",
-        range: "1"
-      }
-    ],
-    month: [
-      {
-        field: fields.dateField,
-        operator: "is during the next",
-        text: "Next Month",
-        type: "months",
-        range: "1"
-      }
-    ]
-  };
+// Keep track of pagination details
+var currentPage = 1;
+var recordsPerPage = 10;
+var numberOfPages = null;
+var currentRangeStart = 1;
+var currentRangeEnd = currentPage - 1 + recordsPerPage;
 
-  // Endpoints
-  var getUrl =
-    "https://api.knack.com/v1/pages/" +
-    appSpecifics.apiTableScene +
-    "/views/" +
-    appSpecifics.apiTableView +
-    "/records";
-
-  var putUrl =
-    "https://api.knack.com/v1/pages/" +
-    appSpecifics.apiTableScene +
-    "/views/" +
-    appSpecifics.apiTableView +
-    "/records/";
-
-  // Get user auth for get request (API view is private) and set req headers
-  var user = Knack.getUserToken();
-  var userId = Knack.getUserAttributes().id;
-
-  var headers = {
-    "X-Knack-Application-ID": appSpecifics.knackAppId,
-    Authorization: user,
-    "content-type": "application/json"
-  };
-
-  function removeKnackTable() {
-    $(
-      "#" + appSpecifics.availableAssignmentsView + "> div.kn-records-nav"
-    ).remove();
-    $(
-      "#" + appSpecifics.availableAssignmentsView + "> div.kn-table-wrapper"
-    ).remove();
-  }
-
-  // Remove Knack generated table that we are replacing and request records
-  removeKnackTable();
-
-  // Setup pagination
-  function initializePagination(records) {
-    currentPage = 1;
-    currentRangeStart = 1;
-    currentRangeEnd = currentPage - 1 + recordsPerPage;
-    numberOfPages = Math.ceil(records.length / recordsPerPage);
-
-    var initialPageRecords = records.slice(0, recordsPerPage);
-    return initialPageRecords;
-  }
-
-  // Request and set initial records
-  function requestRecords(filters) {
-    var url =
-      getUrl +
-      "?filters=" +
-      encodeURIComponent(JSON.stringify(filters)) +
-      "&rows_per_page=1000";
-
-    // Show spinner while fetching officer_assignment records
-    $("#" + appSpecifics.availableAssignmentsView + "> div.view-header").append(
-      `<span id="assignment-spinner" class="icon">&nbsp;<i class="fa fa-circle-o-notch fa-spin"></i></span>`
-    );
-
-    // Request officer_assignment records
-    $.ajax({
-      url: url,
-      type: "GET",
-      headers: headers,
-      success: function (res) {
-        records = res.records;
-
-        // Don't process records if there are none
-        if (records.length === 0) {
-          $("#shift-table-body").children().remove();
-          appendTableWithNoRecordsMessage();
-          $("#assignment-spinner").remove();
-          completeRecords = null;
-          recordsInPage = null;
-          return;
-        }
-
-        completeRecords = groupRecordsIntoAssignments(records);
-        recordsInPage = initializePagination(completeRecords);
-        buildAndAppendShiftSection(recordsInPage);
-        prependShiftTableWithPagination();
-        prependPaginationWithTimeFilters();
-        addOpenShiftButtonClickHandlers();
-        addCancelMyShiftButtonClickHandlers();
-
-        // Remove spinner
-        $("#assignment-spinner").remove();
-      }
-    });
-  }
-
-  // Group officer assignments into shifts
-  function groupRecordsIntoAssignments(records) {
-    // Group records by Officer Shift Label
-    var groupedRecords = {};
-
-    for (var i = 0; i < records.length; i++) {
-      var record = records[i];
-      var officerShift = record[fields.officerShiftField];
-
-      if (groupedRecords[officerShift]) {
-        groupedRecords[officerShift].push(record);
-      } else {
-        groupedRecords[officerShift] = [record];
-      }
+// Filter for records for assignments time windows
+var filters = {
+  all: [
+    {
+      field: fields.dateField,
+      operator: "is today or after"
+    },
+    {
+      field: fields.assignmentDateTimeField,
+      operator: "is not blank"
     }
+  ],
+  week: [
+    {
+      value: "",
+      text: "Next Week",
+      operator: "is during the next",
+      field: fields.dateField,
+      type: "weeks",
+      range: "1"
+    }
+  ],
+  month: [
+    {
+      field: fields.dateField,
+      operator: "is during the next",
+      text: "Next Month",
+      type: "months",
+      range: "1"
+    }
+  ]
+};
 
-    return Object.values(groupedRecords);
+// Endpoints
+var getUrl =
+  "https://api.knack.com/v1/pages/" +
+  appSpecifics.apiTableScene +
+  "/views/" +
+  appSpecifics.apiTableView +
+  "/records";
+
+var putUrl =
+  "https://api.knack.com/v1/pages/" +
+  appSpecifics.apiTableScene +
+  "/views/" +
+  appSpecifics.apiTableView +
+  "/records/";
+
+// Get user auth for get request (API view is private) and set req headers
+var user = Knack.getUserToken();
+var userId = Knack.getUserAttributes().id;
+
+var headers = {
+  "X-Knack-Application-ID": appSpecifics.knackAppId,
+  Authorization: user,
+  "content-type": "application/json"
+};
+
+function removeKnackTable() {
+  $(
+    "#" + appSpecifics.availableAssignmentsView + "> div.kn-records-nav"
+  ).remove();
+  $(
+    "#" + appSpecifics.availableAssignmentsView + "> div.kn-table-wrapper"
+  ).remove();
+}
+
+// Remove Knack generated table that we are replacing and request records
+removeKnackTable();
+
+// Setup pagination
+function initializePagination(records) {
+  currentPage = 1;
+  currentRangeStart = 1;
+  currentRangeEnd = currentPage - 1 + recordsPerPage;
+  numberOfPages = Math.ceil(records.length / recordsPerPage);
+
+  var initialPageRecords = records.slice(0, recordsPerPage);
+  return initialPageRecords;
+}
+
+// Request and set initial records
+function requestRecords(filters) {
+  var url =
+    getUrl +
+    "?filters=" +
+    encodeURIComponent(JSON.stringify(filters)) +
+    "&rows_per_page=1000";
+
+  // Show spinner while fetching officer_assignment records
+  $("#" + appSpecifics.availableAssignmentsView + "> div.view-header").append(
+    `<span id="assignment-spinner" class="icon">&nbsp;<i class="fa fa-circle-o-notch fa-spin"></i></span>`
+  );
+
+  // Request officer_assignment records
+  $.ajax({
+    url: url,
+    type: "GET",
+    headers: headers,
+    success: function (res) {
+      records = res.records;
+
+      // Don't process records if there are none
+      if (records.length === 0) {
+        $("#shift-table-body").children().remove();
+        appendTableWithNoRecordsMessage();
+        $("#assignment-spinner").remove();
+        completeRecords = null;
+        recordsInPage = null;
+        return;
+      }
+
+      completeRecords = groupRecordsIntoAssignments(records);
+      recordsInPage = initializePagination(completeRecords);
+      buildAndAppendShiftSection(recordsInPage);
+      prependShiftTableWithPagination();
+      prependPaginationWithTimeFilters();
+      addOpenShiftButtonClickHandlers();
+      addCancelMyShiftButtonClickHandlers();
+
+      // Remove spinner
+      $("#assignment-spinner").remove();
+    }
+  });
+}
+
+// Group officer assignments into shifts
+function groupRecordsIntoAssignments(records) {
+  // Group records by Officer Shift Label
+  var groupedRecords = {};
+
+  for (var i = 0; i < records.length; i++) {
+    var record = records[i];
+    var officerShift = record[fields.officerShiftField];
+
+    if (groupedRecords[officerShift]) {
+      groupedRecords[officerShift].push(record);
+    } else {
+      groupedRecords[officerShift] = [record];
+    }
   }
 
-  function buildAndAppendShiftSection(shiftRecords) {
-    // Clear the table in case we need to repopulate for pagination
-    $("#shift-table-body").children().remove();
+  return Object.values(groupedRecords);
+}
 
-    function buildShift(records) {
-      var shiftsHTML = ``;
+function buildAndAppendShiftSection(shiftRecords) {
+  // Clear the table in case we need to repopulate for pagination
+  $("#shift-table-body").children().remove();
 
-      records.forEach(function (shiftRecords) {
-        shiftsHTML += `
-          <tr class="kn-table-group kn-group-level-1">
-            <td class="shift-header" colspan="4">${
-              shiftRecords[0][fields.officerShiftField]
-            }</td>
-          </tr>`;
+  function buildShift(records) {
+    var shiftsHTML = ``;
 
-        // Condense each set of officer_assignments that make up a shift together
-        // First dimension is shifts of officer_assignments (grouped together for sign up)
-        // Second dimension is array of officer_assignments within shift
-        // [A,A,B,B,C,C] => [[A,B,C], [A,B,C]]
+    records.forEach(function (shiftRecords) {
+      shiftsHTML += `
+        <tr class="kn-table-group kn-group-level-1">
+          <td class="shift-header" colspan="4">${
+            shiftRecords[0][fields.officerShiftField]
+          }</td>
+        </tr>`;
 
-        var buttonRecords = [];
+      // Condense each set of officer_assignments that make up a shift together
+      // First dimension is shifts of officer_assignments (grouped together for sign up)
+      // Second dimension is array of officer_assignments within shift
+      // [A,A,B,B,C,C] => [[A,B,C], [A,B,C]]
 
-        if (shiftRecords.length !== 0) {
-          var currentArrayPosition = 0;
-          var currentSubarrayPosition = 0;
+      var buttonRecords = [];
 
-          function isSameTime(record1, record2) {
-            return record1[fields.timeField] === record2[fields.timeField];
-          }
+      if (shiftRecords.length !== 0) {
+        var currentArrayPosition = 0;
+        var currentSubarrayPosition = 0;
 
-          for (var i = 0; i < shiftRecords.length; i++) {
-            if (i === 0) {
-              buttonRecords.push([shiftRecords[i]]);
-              currentArrayPosition++;
-            } else if (
-              isSameTime(
-                shiftRecords[i],
-                buttonRecords[currentArrayPosition - 1][currentSubarrayPosition]
-              ) &&
-              currentSubarrayPosition === 0
-            ) {
-              buttonRecords.push([shiftRecords[i]]);
-              currentArrayPosition++;
-            } else if (
-              !isSameTime(
-                shiftRecords[i],
-                buttonRecords[currentArrayPosition - 1][currentSubarrayPosition]
-              )
-            ) {
-              currentSubarrayPosition++;
-              currentArrayPosition = 0;
-              buttonRecords[currentArrayPosition].push(shiftRecords[i]);
-              currentArrayPosition++;
-            } else if (
-              isSameTime(
-                shiftRecords[i],
-                buttonRecords[currentArrayPosition - 1][currentSubarrayPosition]
-              ) &&
-              currentSubarrayPosition > 0
-            ) {
-              buttonRecords[currentArrayPosition].push(shiftRecords[i]);
-              currentArrayPosition++;
-            }
-          }
+        function isSameTime(record1, record2) {
+          return record1[fields.timeField] === record2[fields.timeField];
         }
 
-        buttonRecords[0].forEach(function (record) {
-          shiftsHTML += `
-            <tr>
-              <td
-                style="padding-left: 20px;"
-                data-column-index="1"
-              >
-                <span class="col-1">
-                  ${record[fields.timeField]}
-                </span>
-              </td>
-              <td data-column-index="2">
-                <span class="col-2">
-                  <span>${
-                    record[fields.locationFieldRaw][0].identifier.split(
-                      " - "
-                    )[0]
-                  }</span>
-                </span>
-              </td>
-              <td data-column-index="3">
-                <span class="col-3">
-                  <span
-                    >${
-                      record[fields.locationFieldRaw][0].identifier.split(
-                        " - "
-                      )[2]
-                    }</span
-                  >
-                </span>
-              </td>
-            </tr>
-            `;
-        });
+        for (var i = 0; i < shiftRecords.length; i++) {
+          if (i === 0) {
+            buttonRecords.push([shiftRecords[i]]);
+            currentArrayPosition++;
+          } else if (
+            isSameTime(
+              shiftRecords[i],
+              buttonRecords[currentArrayPosition - 1][currentSubarrayPosition]
+            ) &&
+            currentSubarrayPosition === 0
+          ) {
+            buttonRecords.push([shiftRecords[i]]);
+            currentArrayPosition++;
+          } else if (
+            !isSameTime(
+              shiftRecords[i],
+              buttonRecords[currentArrayPosition - 1][currentSubarrayPosition]
+            )
+          ) {
+            currentSubarrayPosition++;
+            currentArrayPosition = 0;
+            buttonRecords[currentArrayPosition].push(shiftRecords[i]);
+            currentArrayPosition++;
+          } else if (
+            isSameTime(
+              shiftRecords[i],
+              buttonRecords[currentArrayPosition - 1][currentSubarrayPosition]
+            ) &&
+            currentSubarrayPosition > 0
+          ) {
+            buttonRecords[currentArrayPosition].push(shiftRecords[i]);
+            currentArrayPosition++;
+          }
+        }
+      }
 
-        // Add sign up buttons
+      buttonRecords[0].forEach(function (record) {
         shiftsHTML += `
           <tr>
-            <td style="padding-top: 16px;" colspan="4">
-          `;
-
-        function setButtonStatus(
-          isMyAssignment,
-          isOtherOfficerAssignment,
-          isNotAssigned
-        ) {
-          if (isNotAssigned) {
-            return "open-shift-button";
-          } else if (isMyAssignment) {
-            return "my-shift-button";
-          } else if (isOtherOfficerAssignment) {
-            return "is-disabled";
-          }
-        }
-
-        // For each subarray, add one button
-        buttonRecords.forEach(function (shift, i) {
-          // Build the button id from shift officer assignment ids for use by sign up click handler
-          const buttonId = shift
-            .map(function (assignment) {
-              return assignment.id;
-            })
-            .join("-");
-
-          var assignmentOfficerId =
-            shift[0][fields.assignedOfficerFieldRaw][0].id;
-          var isMyAssignment = assignmentOfficerId === userId;
-          var isOtherOfficerAssignment =
-            assignmentOfficerId !== userId &&
-            assignmentOfficerId !== appSpecifics.noOfficerAssignedId;
-          var isNotAssigned =
-            assignmentOfficerId === appSpecifics.noOfficerAssignedId;
-
-          shiftsHTML += `
-            <span
-            class="kn-button ${setButtonStatus(
-              isMyAssignment,
-              isOtherOfficerAssignment,
-              isNotAssigned
-            )}"
-            style="margin: 0px 10px 10px 0px;"
-            id="${buttonId}"
+            <td
+              style="padding-left: 20px;"
+              data-column-index="1"
             >
-              <span class="icon">
-                ${
-                  (isNotAssigned && `<i class="fa fa-plus-square"></i>`) ||
-                  (isOtherOfficerAssignment &&
-                    `<i class="fa fa-check-square-o"></i>`) ||
-                  (isMyAssignment && `<i class="fa fa-times-circle"></i>`)
-                }
+              <span class="col-1">
+                ${record[fields.timeField]}
               </span>
-              <span>
-              ${
-                (isNotAssigned && `Sign up - Officer ${i + 1}`) ||
-                (isOtherOfficerAssignment && `Filled - Officer ${i + 1}`) ||
-                (isMyAssignment && `Cancel My Sign Up`)
-              }
-             </span>
-            </span>
-            `;
-        });
+            </td>
+            <td data-column-index="2">
+              <span class="col-2">
+                <span>${
+                  record[fields.locationFieldRaw][0].identifier.split(" - ")[0]
+                }</span>
+              </span>
+            </td>
+            <td data-column-index="3">
+              <span class="col-3">
+                <span
+                  >${
+                    record[fields.locationFieldRaw][0].identifier.split(
+                      " - "
+                    )[2]
+                  }</span
+                >
+              </span>
+            </td>
+          </tr>
+          `;
+      });
+
+      // Add sign up buttons
+      shiftsHTML += `
+        <tr>
+          <td style="padding-top: 16px;" colspan="4">
+        `;
+
+      function setButtonStatus(
+        isMyAssignment,
+        isOtherOfficerAssignment,
+        isNotAssigned
+      ) {
+        if (isNotAssigned) {
+          return "open-shift-button";
+        } else if (isMyAssignment) {
+          return "my-shift-button";
+        } else if (isOtherOfficerAssignment) {
+          return "is-disabled";
+        }
+      }
+
+      // For each subarray, add one button
+      buttonRecords.forEach(function (shift, i) {
+        // Build the button id from shift officer assignment ids for use by sign up click handler
+        const buttonId = shift
+          .map(function (assignment) {
+            return assignment.id;
+          })
+          .join("-");
+
+        var assignmentOfficerId =
+          shift[0][fields.assignedOfficerFieldRaw][0].id;
+        var isMyAssignment = assignmentOfficerId === userId;
+        var isOtherOfficerAssignment =
+          assignmentOfficerId !== userId &&
+          assignmentOfficerId !== appSpecifics.noOfficerAssignedId;
+        var isNotAssigned =
+          assignmentOfficerId === appSpecifics.noOfficerAssignedId;
 
         shiftsHTML += `
-            </td>
-          </tr>`;
-      });
-
-      return shiftsHTML;
-    }
-
-    var shiftSection = buildShift(shiftRecords);
-    $("#shift-table-body").append(shiftSection);
-  }
-
-  function findRecordById(id) {
-    var found = null;
-
-    for (var i = 0; i < completeRecords.length; i++) {
-      found = completeRecords[i].find(function (record) {
-        return record.id === id;
-      });
-
-      if (!!found) {
-        break;
-      }
-    }
-
-    return found;
-  }
-
-  // Add button handler to associate officer assignment records with logged in user
-  function addOpenShiftButtonClickHandlers() {
-    var buttons = $(`.open-shift-button`);
-    buttons.each(function () {
-      var thisButton = $(this);
-      var thisButtonIcon = thisButton.find("i");
-
-      // Remove any existing click handler
-      thisButton.off("click");
-
-      thisButton.click(function () {
-        // Get officer_assignment record ids
-        var idsToAssignCurrentUser = thisButton.attr("id").split("-");
-        thisButton.removeClass("open-shift-button");
-        thisButtonIcon
-          .removeClass("fa-plus-square")
-          .addClass("fa-circle-o-notch fa-spin");
-
-        idsToAssignCurrentUser.forEach(function (recordId) {
-          $.ajax({
-            url: putUrl + recordId,
-            type: "PUT",
-            data: JSON.stringify({ [fields.assignedOfficerField]: userId }),
-            headers: headers,
-            success: function (res) {
-              thisButton.addClass("my-shift-button");
-              thisButton[0].children[1].innerText = "Cancel My Sign Up";
-              thisButtonIcon
-                .removeClass("fa-circle-o-notch fa-spin")
-                .addClass("fa-times-circle");
-
-              addCancelMyShiftButtonClickHandlers();
-
-              // Update cached record
-              var thisRecord = findRecordById(recordId);
-              thisRecord[fields.assignedOfficerFieldRaw][0].id = userId;
-
-              $.ajax({
-                url: putUrl + recordId,
-                type: "PUT",
-                data: JSON.stringify({
-                  action_link_index: 0,
-                  id: recordId
-                }),
-                headers: headers,
-                success: function (res) {
-                  console.log(res);
-                }
-              });
+          <span
+          class="kn-button ${setButtonStatus(
+            isMyAssignment,
+            isOtherOfficerAssignment,
+            isNotAssigned
+          )}"
+          style="margin: 0px 10px 10px 0px;"
+          id="${buttonId}"
+          >
+            <span class="icon">
+              ${
+                (isNotAssigned && `<i class="fa fa-plus-square"></i>`) ||
+                (isOtherOfficerAssignment &&
+                  `<i class="fa fa-check-square-o"></i>`) ||
+                (isMyAssignment && `<i class="fa fa-times-circle"></i>`)
+              }
+            </span>
+            <span>
+            ${
+              (isNotAssigned && `Sign up - Officer ${i + 1}`) ||
+              (isOtherOfficerAssignment && `Filled - Officer ${i + 1}`) ||
+              (isMyAssignment && `Cancel My Sign Up`)
             }
-          });
-        });
+           </span>
+          </span>
+          `;
       });
+
+      shiftsHTML += `
+          </td>
+        </tr>`;
     });
+
+    return shiftsHTML;
   }
 
-  function addCancellationModal(
-    recordIdsString,
-    buttonNumber,
-    thisButton,
-    thisButtonIcon
-  ) {
-    var cancellationForm = `
-    <div
-    id="kn-modal-bg-0"
-    class="kn-modal-bg cancellation-modal"
-    style="top: 0px; z-index: 2000; display: block"
-    >
-      <div class="kn-modal default" style="display: block">
-        <header class="modal-card-head">
-          <h1 class="modal-card-title">Remove From Today's Assignments</h1>
-          <button class="delete close-cancellation-modal"></button>
-        </header>
-        <section class="modal-card-body kn-page-modal" id="kn-page-modal-0">
-          <div class="kn-scene kn-container" id="kn-scene_236">
-            <div class="kn-form kn-view view_484" id="view_484">
-              <form id="cancellation-form">
-                <ul class="kn-form-group columns kn-form-group-1">
-                  <li class="kn-form-col column is-constrained">
-                    <div
-                      class="kn-input kn-input-short_text control"
-                      id="kn-input-field_671"
-                      data-input-id="field_671"
-                    >
-                      <label for="field_671" class="label kn-label"
-                        ><span>Reason for Cancellation</span></label
-                      >
-                      <div class="control">
-                        <input
-                          class="input"
-                          id="field_671"
-                          name="field_671"
-                          type="text"
-                          value=""
-                        />
-                      </div>
-                      <p class="kn-instructions" style="display: none"></p>
-                    </div>
-                    <div
-                      class="kn-input kn-input-boolean control"
-                      id="kn-input-field_711"
-                      data-input-id="field_711"
-                    >
-                      <label for="field_711" class="label kn-label"
-                        ><span>Remove From My Assignments</span></label
-                      >
-                      <div class="control">
-                        <label class="option checkbox"
-                          ><input
-                            type="checkbox"
-                            name="field_711"
-                            value="Yes"
-                          />&nbsp;I have read the SEU Cancellation Policy and
-                          understand that by cancelling this assignment with less
-                          than 48 hours notice I am responsible for finding another
-                          Officer to work the shift or risk losing eligibility for
-                          SEU assignments.</label
-                        >
-                      </div>
-                      <p class="kn-instructions">
-                        <a
-                          href="https://docs.google.com/document/d/1cODXt1FuJVHAmiSg23hdcQDrfcFaiKhUmVOiFxgJ-4g/edit?usp=sharing"
-                          >Cancellation Policy</a
-                        >
-                      </p>
-                    </div>
-                  </li>
-                </ul>
-                <div class="kn-submit">    
-                  <button class="kn-button is-primary" type="submit">Submit</button>
-                </div>
-              </form>
-            </div>
-          </div>
-        </section>
-      </div>
-    </div>
-    `;
+  var shiftSection = buildShift(shiftRecords);
+  $("#shift-table-body").append(shiftSection);
+}
 
-    // Append cancellation modal and handle form submit
-    $(".kn-content").append(cancellationForm);
-    var thisForm = $("#cancellation-form");
-    thisForm.off("submit");
-    thisForm.on("submit", function (e) {
-      e.preventDefault();
+function findRecordById(id) {
+  var found = null;
 
-      // Collect form values
-      var formFields = thisForm.serializeArray();
-      var knackFormatFields = formFields.reduce(function (acc, field) {
-        return { ...acc, [field.name]: field.value };
-      }, {});
+  for (var i = 0; i < completeRecords.length; i++) {
+    found = completeRecords[i].find(function (record) {
+      return record.id === id;
+    });
 
-      // Start spinner
-      $("#kn-loading-spinner").css("display", "block");
+    if (!!found) {
+      break;
+    }
+  }
 
-      // Submit PUT requests to modify each officer_assignment ID stored in button id attribute
-      var idsToAssignCurrentUser = recordIdsString.split("-");
+  return found;
+}
 
-      var now = new Date().toLocaleString();
+// Add button handler to associate officer assignment records with logged in user
+function addOpenShiftButtonClickHandlers() {
+  var buttons = $(`.open-shift-button`);
+  buttons.each(function () {
+    var thisButton = $(this);
+    var thisButtonIcon = thisButton.find("i");
+
+    // Remove any existing click handler
+    thisButton.off("click");
+
+    thisButton.click(function () {
+      // Get officer_assignment record ids
+      var idsToAssignCurrentUser = thisButton.attr("id").split("-");
+      thisButton.removeClass("open-shift-button");
+      thisButtonIcon
+        .removeClass("fa-plus-square")
+        .addClass("fa-circle-o-notch fa-spin");
 
       idsToAssignCurrentUser.forEach(function (recordId) {
         $.ajax({
           url: putUrl + recordId,
           type: "PUT",
-          data: JSON.stringify({
-            ...knackFormatFields, // Reason for cancellation and Remove from My Assignments fields from form
-            [fields.assignedOfficerField]: appSpecifics.noOfficerAssignedId, // Add unassigned officer ID
-            [fields.unassignedOfficerField]: userId, // Add current user as unassigned officer to track who cancelled
-            [fields.addToMyAssignmentsField]: "No", // Add to My Assignments
-            [fields.dateTimeOfCancellationField]: now // DateTime of cancellation
-          }),
+          data: JSON.stringify({ [fields.assignedOfficerField]: userId }),
           headers: headers,
           success: function (res) {
-            // Switch button associated with these records back to a Sign Up button
-            thisButton
-              .removeClass("my-shift-button")
-              .addClass("open-shift-button");
-            thisButton[0].children[1].innerText = `Sign Up - Officer ${buttonNumber}`;
+            thisButton.addClass("my-shift-button");
+            thisButton[0].children[1].innerText = "Cancel My Sign Up";
             thisButtonIcon
-              .removeClass("fa-times-circle")
-              .addClass("fa-plus-square");
-            addOpenShiftButtonClickHandlers();
+              .removeClass("fa-circle-o-notch fa-spin")
+              .addClass("fa-times-circle");
+
+            addCancelMyShiftButtonClickHandlers();
 
             // Update cached record
             var thisRecord = findRecordById(recordId);
-            thisRecord[fields.assignedOfficerFieldRaw][0].id =
-              appSpecifics.noOfficerAssignedId;
+            thisRecord[fields.assignedOfficerFieldRaw][0].id = userId;
 
-            // Remove modal and stop spinner
-            $("#kn-modal-bg-0").remove();
-            $("#kn-loading-spinner").css("display", "none");
+            $.ajax({
+              url: putUrl + recordId,
+              type: "PUT",
+              data: JSON.stringify({
+                action_link_index: 0,
+                id: recordId
+              }),
+              headers: headers,
+              success: function (res) {
+                console.log(res);
+              }
+            });
           }
         });
       });
     });
+  });
+}
 
-    // Add click handler to close modal (X) button
-    var closeModalButton = $(".close-cancellation-modal");
-    closeModalButton.off("click");
-    closeModalButton.click(function () {
-      $(".cancellation-modal").remove();
-    });
-  }
+function addCancellationModal(
+  recordIdsString,
+  buttonNumber,
+  thisButton,
+  thisButtonIcon
+) {
+  var cancellationForm = `
+  <div
+  id="kn-modal-bg-0"
+  class="kn-modal-bg cancellation-modal"
+  style="top: 0px; z-index: 2000; display: block"
+  >
+    <div class="kn-modal default" style="display: block">
+      <header class="modal-card-head">
+        <h1 class="modal-card-title">Remove From Today's Assignments</h1>
+        <button class="delete close-cancellation-modal"></button>
+      </header>
+      <section class="modal-card-body kn-page-modal" id="kn-page-modal-0">
+        <div class="kn-scene kn-container" id="kn-scene_236">
+          <div class="kn-form kn-view view_484" id="view_484">
+            <form id="cancellation-form">
+              <ul class="kn-form-group columns kn-form-group-1">
+                <li class="kn-form-col column is-constrained">
+                  <div
+                    class="kn-input kn-input-short_text control"
+                    id="kn-input-field_671"
+                    data-input-id="field_671"
+                  >
+                    <label for="field_671" class="label kn-label"
+                      ><span>Reason for Cancellation</span></label
+                    >
+                    <div class="control">
+                      <input
+                        class="input"
+                        id="field_671"
+                        name="field_671"
+                        type="text"
+                        value=""
+                      />
+                    </div>
+                    <p class="kn-instructions" style="display: none"></p>
+                  </div>
+                  <div
+                    class="kn-input kn-input-boolean control"
+                    id="kn-input-field_711"
+                    data-input-id="field_711"
+                  >
+                    <label for="field_711" class="label kn-label"
+                      ><span>Remove From My Assignments</span></label
+                    >
+                    <div class="control">
+                      <label class="option checkbox"
+                        ><input
+                          type="checkbox"
+                          name="field_711"
+                          value="Yes"
+                        />&nbsp;I have read the SEU Cancellation Policy and
+                        understand that by cancelling this assignment with less
+                        than 48 hours notice I am responsible for finding another
+                        Officer to work the shift or risk losing eligibility for
+                        SEU assignments.</label
+                      >
+                    </div>
+                    <p class="kn-instructions">
+                      <a
+                        href="https://docs.google.com/document/d/1cODXt1FuJVHAmiSg23hdcQDrfcFaiKhUmVOiFxgJ-4g/edit?usp=sharing"
+                        >Cancellation Policy</a
+                      >
+                    </p>
+                  </div>
+                </li>
+              </ul>
+              <div class="kn-submit">    
+                <button class="kn-button is-primary" type="submit">Submit</button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </section>
+    </div>
+  </div>
+  `;
 
-  function addCancelMyShiftButtonClickHandlers() {
-    var buttons = $(`.my-shift-button`);
-    buttons.each(function () {
-      var thisButton = $(this);
-      var thisButtonIcon = thisButton.find("i");
-      // Use this to display the Officer number in the button that corresponds with its position in the UI
-      var buttonNumber = thisButton.index() + 1;
+  // Append cancellation modal and handle form submit
+  $(".kn-content").append(cancellationForm);
+  var thisForm = $("#cancellation-form");
+  thisForm.off("submit");
+  thisForm.on("submit", function (e) {
+    e.preventDefault();
 
-      // Remove any existing click handler
-      thisButton.off("click");
+    // Collect form values
+    var formFields = thisForm.serializeArray();
+    var knackFormatFields = formFields.reduce(function (acc, field) {
+      return { ...acc, [field.name]: field.value };
+    }, {});
 
-      thisButton.click(function () {
-        var recordIdsString = thisButton.attr("id");
-        addCancellationModal(
-          recordIdsString,
-          buttonNumber,
-          thisButton,
+    // Start spinner
+    $("#kn-loading-spinner").css("display", "block");
+
+    // Submit PUT requests to modify each officer_assignment ID stored in button id attribute
+    var idsToAssignCurrentUser = recordIdsString.split("-");
+
+    var now = new Date().toLocaleString();
+
+    idsToAssignCurrentUser.forEach(function (recordId) {
+      $.ajax({
+        url: putUrl + recordId,
+        type: "PUT",
+        data: JSON.stringify({
+          ...knackFormatFields, // Reason for cancellation and Remove from My Assignments fields from form
+          [fields.assignedOfficerField]: appSpecifics.noOfficerAssignedId, // Add unassigned officer ID
+          [fields.unassignedOfficerField]: userId, // Add current user as unassigned officer to track who cancelled
+          [fields.addToMyAssignmentsField]: "No", // Add to My Assignments
+          [fields.dateTimeOfCancellationField]: now // DateTime of cancellation
+        }),
+        headers: headers,
+        success: function (res) {
+          // Switch button associated with these records back to a Sign Up button
+          thisButton
+            .removeClass("my-shift-button")
+            .addClass("open-shift-button");
+          thisButton[0].children[1].innerText = `Sign Up - Officer ${buttonNumber}`;
           thisButtonIcon
-        );
+            .removeClass("fa-times-circle")
+            .addClass("fa-plus-square");
+          addOpenShiftButtonClickHandlers();
+
+          // Update cached record
+          var thisRecord = findRecordById(recordId);
+          thisRecord[fields.assignedOfficerFieldRaw][0].id =
+            appSpecifics.noOfficerAssignedId;
+
+          // Remove modal and stop spinner
+          $("#kn-modal-bg-0").remove();
+          $("#kn-loading-spinner").css("display", "none");
+        }
       });
     });
-  }
+  });
 
-  // Add button handler to associate officer assignment records with logged in user
-  function addPaginationClickHandlers(prevClass, nextClass) {
-    var prev = $(`.${prevClass}`);
-    var next = $(`.${nextClass}`);
+  // Add click handler to close modal (X) button
+  var closeModalButton = $(".close-cancellation-modal");
+  closeModalButton.off("click");
+  closeModalButton.click(function () {
+    $(".cancellation-modal").remove();
+  });
+}
 
-    prev.click(function () {
-      if (currentPage === 1) {
-        return;
-      }
+function addCancelMyShiftButtonClickHandlers() {
+  var buttons = $(`.my-shift-button`);
+  buttons.each(function () {
+    var thisButton = $(this);
+    var thisButtonIcon = thisButton.find("i");
+    // Use this to display the Officer number in the button that corresponds with its position in the UI
+    var buttonNumber = thisButton.index() + 1;
 
-      currentPage--;
-      currentRangeStart -= recordsPerPage;
-      if (currentPage === numberOfPages - 1) {
-        currentRangeEnd = currentRangeStart + recordsPerPage - 1;
-      } else {
-        currentRangeEnd -= recordsPerPage;
-      }
+    // Remove any existing click handler
+    thisButton.off("click");
 
-      var prevPageRecords = completeRecords.slice(
-        currentRangeStart - 1,
-        currentRangeEnd
+    thisButton.click(function () {
+      var recordIdsString = thisButton.attr("id");
+      addCancellationModal(
+        recordIdsString,
+        buttonNumber,
+        thisButton,
+        thisButtonIcon
       );
-      var shifts = buildAndAppendShiftSection(prevPageRecords);
-      $("#shift-table-body").append(shifts);
-      prependShiftTableWithPagination();
-      addOpenShiftButtonClickHandlers();
-      addCancelMyShiftButtonClickHandlers();
     });
+  });
+}
 
-    next.click(function () {
-      if (currentPage === numberOfPages) {
-        return;
-      }
+// Add button handler to associate officer assignment records with logged in user
+function addPaginationClickHandlers(prevClass, nextClass) {
+  var prev = $(`.${prevClass}`);
+  var next = $(`.${nextClass}`);
 
-      currentPage++;
-      currentRangeStart += recordsPerPage;
-      if (currentPage === numberOfPages) {
-        currentRangeEnd = completeRecords.length;
-      } else {
-        currentRangeEnd += recordsPerPage;
-      }
-
-      var nextPageRecords = completeRecords.slice(
-        currentRangeStart - 1,
-        currentRangeEnd
-      );
-      var shifts = buildAndAppendShiftSection(nextPageRecords);
-      $("#shift-table-body").append(shifts);
-      prependShiftTableWithPagination();
-      addOpenShiftButtonClickHandlers();
-      addCancelMyShiftButtonClickHandlers();
-    });
-  }
-
-  // Update pagination values and add control click handlers
-  function prependShiftTableWithPagination() {
-    if ($(".pagination-controls").length) {
-      $(".pagination-controls").remove();
-    }
-
-    var paginationControls = `
-      <div class="level pagination-controls" style="margin-bottom: .75em;">
-        <div class="level-left">
-          <div class="kn-entries-summary" style="margin-right: .5em;">
-            <span class="light">Showing</span> ${currentRangeStart}-${Math.min(
-      currentRangeEnd,
-      completeRecords.length
-    )}
-            <span class="light">of</span> ${completeRecords.length}
-          </div>
-        </div>
-        <div class="kn-pagination level-right">
-          <div class="kn-total-pages">${currentPage} of ${numberOfPages}</div>
-          <div class="pagination-arrows">
-            <span class="icon prev-arrow">
-              <i class="fa fa-chevron-left"></i>
-            </span>
-            <span class="icon next-arrow">
-              <i class="fa fa-chevron-right"></i>
-            </span>
-          </div>
-        </div>
-      </div>`;
-
-    $(".assignments-table").before(paginationControls);
-    $(".assignments-table").after(paginationControls);
-    addPaginationClickHandlers("prev-arrow", "next-arrow");
-  }
-
-  // Add time filters once, add click handlers to add filters to record request and handle active/inactive button status
-  function prependPaginationWithTimeFilters() {
-    if ($("#time-filter-buttons").length) {
+  prev.click(function () {
+    if (currentPage === 1) {
       return;
     }
 
-    var filterMenu = `
-      <div class="js-filter-menu tabs is-toggle is-flush">
-        <ul id="time-filter-buttons">
-          <li class="is-active" id="all">
-            <a>
-              <span>All</span>
-            </a>
-          </li>
-          <li id="week">
-            <a>
-              <span>Next Week</span>
-            </a>
-          </li>
-          <li id="month">
-            <a>
-              <span>Next Month</span>
-            </a>
-            </li>
-         </ul>
-      </div>`;
+    currentPage--;
+    currentRangeStart -= recordsPerPage;
+    if (currentPage === numberOfPages - 1) {
+      currentRangeEnd = currentRangeStart + recordsPerPage - 1;
+    } else {
+      currentRangeEnd -= recordsPerPage;
+    }
 
-    $(".pagination-controls")
-      .before(filterMenu)
-      .ready(function () {
-        $("#time-filter-buttons")
-          .children()
-          .each(function () {
-            // Request records with matching time filter on click
-            $(this).click(function () {
-              var clickedFilterButtonId = $(this).attr("id");
-              requestRecords(filters[clickedFilterButtonId]);
+    var prevPageRecords = completeRecords.slice(
+      currentRangeStart - 1,
+      currentRangeEnd
+    );
+    var shifts = buildAndAppendShiftSection(prevPageRecords);
+    $("#shift-table-body").append(shifts);
+    prependShiftTableWithPagination();
+    addOpenShiftButtonClickHandlers();
+    addCancelMyShiftButtonClickHandlers();
+  });
 
-              // Add/remove active button status
-              $("#time-filter-buttons")
-                .children()
-                .each(function () {
-                  var thisFilterButtonId = $(this).attr("id");
-                  if (thisFilterButtonId === clickedFilterButtonId) {
-                    $(this).addClass("is-active");
-                  } else {
-                    $(this).removeClass("is-active");
-                  }
-                });
-            });
-          });
-      });
-  }
-
-  function appendTableWithNoRecordsMessage() {
-    if ($("#no-records-msg").length) {
+  next.click(function () {
+    if (currentPage === numberOfPages) {
       return;
     }
 
-    var noRecordsRow = `
-      <tr class="kn-table-group kn-group-level-1" id="no-records-msg">
-        <td colspan="4">No assignments available</td>
-      </tr>  
-    `;
+    currentPage++;
+    currentRangeStart += recordsPerPage;
+    if (currentPage === numberOfPages) {
+      currentRangeEnd = completeRecords.length;
+    } else {
+      currentRangeEnd += recordsPerPage;
+    }
 
-    $("#shift-table-body").append(noRecordsRow);
+    var nextPageRecords = completeRecords.slice(
+      currentRangeStart - 1,
+      currentRangeEnd
+    );
+    var shifts = buildAndAppendShiftSection(nextPageRecords);
+    $("#shift-table-body").append(shifts);
+    prependShiftTableWithPagination();
+    addOpenShiftButtonClickHandlers();
+    addCancelMyShiftButtonClickHandlers();
+  });
+}
+
+// Update pagination values and add control click handlers
+function prependShiftTableWithPagination() {
+  if ($(".pagination-controls").length) {
+    $(".pagination-controls").remove();
   }
 
-  // Table to receive formatted table body
-  var recordsTable = `
-    <div class="assignments-table">
-      <table class="kn-table kn-table-table is-bordered">
-        <thead>
-          <tr>
-            <th>
-              <span class="table-fixed-label">
-                <span>Time</span>
-              </span>
-            </th>
-            <th>
-              <span class="table-fixed-label">
-                <span>Sector</span>
-              </span>
-            </th>
-            <th>
-              <span class="table-fixed-label">
-                <span>Location</span>
-              </span>
-            </th>
-          </tr>
-        </thead>
-        <tbody id="shift-table-body">
-        </tbody>
-      </table>
+  var paginationControls = `
+    <div class="level pagination-controls" style="margin-bottom: .75em;">
+      <div class="level-left">
+        <div class="kn-entries-summary" style="margin-right: .5em;">
+          <span class="light">Showing</span> ${currentRangeStart}-${Math.min(
+    currentRangeEnd,
+    completeRecords.length
+  )}
+          <span class="light">of</span> ${completeRecords.length}
+        </div>
+      </div>
+      <div class="kn-pagination level-right">
+        <div class="kn-total-pages">${currentPage} of ${numberOfPages}</div>
+        <div class="pagination-arrows">
+          <span class="icon prev-arrow">
+            <i class="fa fa-chevron-left"></i>
+          </span>
+          <span class="icon next-arrow">
+            <i class="fa fa-chevron-right"></i>
+          </span>
+        </div>
+      </div>
     </div>`;
 
+  $(".assignments-table").before(paginationControls);
+  $(".assignments-table").after(paginationControls);
+  addPaginationClickHandlers("prev-arrow", "next-arrow");
+}
+
+// Add time filters once, add click handlers to add filters to record request and handle active/inactive button status
+function prependPaginationWithTimeFilters() {
+  if ($("#time-filter-buttons").length) {
+    return;
+  }
+
+  var filterMenu = `
+    <div class="js-filter-menu tabs is-toggle is-flush">
+      <ul id="time-filter-buttons">
+        <li class="is-active" id="all">
+          <a>
+            <span>All</span>
+          </a>
+        </li>
+        <li id="week">
+          <a>
+            <span>Next Week</span>
+          </a>
+        </li>
+        <li id="month">
+          <a>
+            <span>Next Month</span>
+          </a>
+          </li>
+       </ul>
+    </div>`;
+
+  $(".pagination-controls")
+    .before(filterMenu)
+    .ready(function () {
+      $("#time-filter-buttons")
+        .children()
+        .each(function () {
+          // Request records with matching time filter on click
+          $(this).click(function () {
+            var clickedFilterButtonId = $(this).attr("id");
+            requestRecords(filters[clickedFilterButtonId]);
+
+            // Add/remove active button status
+            $("#time-filter-buttons")
+              .children()
+              .each(function () {
+                var thisFilterButtonId = $(this).attr("id");
+                if (thisFilterButtonId === clickedFilterButtonId) {
+                  $(this).addClass("is-active");
+                } else {
+                  $(this).removeClass("is-active");
+                }
+              });
+          });
+        });
+    });
+}
+
+function appendTableWithNoRecordsMessage() {
+  if ($("#no-records-msg").length) {
+    return;
+  }
+
+  var noRecordsRow = `
+    <tr class="kn-table-group kn-group-level-1" id="no-records-msg">
+      <td colspan="4">No assignments available</td>
+    </tr>  
+  `;
+
+  $("#shift-table-body").append(noRecordsRow);
+}
+
+// Table to receive formatted table body
+var recordsTable = `
+  <div class="assignments-table">
+    <table class="kn-table kn-table-table is-bordered">
+      <thead>
+        <tr>
+          <th>
+            <span class="table-fixed-label">
+              <span>Time</span>
+            </span>
+          </th>
+          <th>
+            <span class="table-fixed-label">
+              <span>Sector</span>
+            </span>
+          </th>
+          <th>
+            <span class="table-fixed-label">
+              <span>Location</span>
+            </span>
+          </th>
+        </tr>
+      </thead>
+      <tbody id="shift-table-body">
+      </tbody>
+    </table>
+  </div>`;
+
+// Sign Up page
+// Hide Knack generated "Available Assignments" table, create and add table that condenses
+// sign up for multiple officer_assignments into one button
+$(document).on("knack-view-render.view_466", function (event, view, data) {
   // Append table, then request records and append shifts to table body
   $("#" + appSpecifics.availableAssignmentsView + "> div.view-header")
     .after(recordsTable)
     .ready(function () {
       requestRecords(filters.all);
     });
-});
-
-// Assignment Details page
-// Update start button text
-$(document).on("knack-view-render.view_449", function (event, view, data) {
-  $("#view_449 button strong")[0].innerText = " Start Assignment";
 });

--- a/code/vza/vza.js
+++ b/code/vza/vza.js
@@ -114,6 +114,8 @@ $(document).on("knack-view-render.view_466", function (event, view, data) {
   // Setup pagination
   function initializePagination(records) {
     currentPage = 1;
+    currentRangeStart = 1;
+    currentRangeEnd = currentPage - 1 + recordsPerPage;
     numberOfPages = Math.ceil(records.length / recordsPerPage);
 
     var initialPageRecords = records.slice(0, recordsPerPage);

--- a/code/vza/vza.js
+++ b/code/vza/vza.js
@@ -802,9 +802,6 @@ $(document).on("knack-view-render.view_466", function (event, view, data) {
     });
 });
 
-$(document).on("knack-view-render.view_448", function (event, view, data) {
-  // #view_449 > section > div > div > div > div > div > div > span > a > h2 > button > strong
-  console.log(data);
-  if (data) {
-  }
+$(document).on("knack-view-render.view_449", function (event, view, data) {
+  $("#view_449 button strong")[0].innerText = " Start Assignment";
 });

--- a/code/vza/vza.js
+++ b/code/vza/vza.js
@@ -214,7 +214,7 @@ $(document).on("knack-view-render.view_466", function (event, view, data) {
             return record1[fields.timeField] === record2[fields.timeField];
           }
 
-          for (let i = 0; i < shiftRecords.length; i++) {
+          for (var i = 0; i < shiftRecords.length; i++) {
             if (i === 0) {
               buttonRecords.push([shiftRecords[i]]);
               currentArrayPosition++;
@@ -367,10 +367,11 @@ $(document).on("knack-view-render.view_466", function (event, view, data) {
   function findRecordById(id) {
     var found = null;
 
-    for (let i = 0; i < completeRecords.length; i++) {
+    for (var i = 0; i < completeRecords.length; i++) {
       found = completeRecords[i].find(function (record) {
         return record.id === id;
       });
+
       if (!!found) {
         break;
       }
@@ -498,7 +499,6 @@ $(document).on("knack-view-render.view_466", function (event, view, data) {
                           SEU assignments.</label
                         >
                       </div>
-                      <input name="key" type="hidden" value="field_711" />
                       <p class="kn-instructions">
                         <a
                           href="https://docs.google.com/document/d/1cODXt1FuJVHAmiSg23hdcQDrfcFaiKhUmVOiFxgJ-4g/edit?usp=sharing"
@@ -526,14 +526,10 @@ $(document).on("knack-view-render.view_466", function (event, view, data) {
     thisForm.on("submit", function (e) {
       e.preventDefault();
 
-      // Collect form values and create payload for officer_assignment records
-      var formAllFields = thisForm.serializeArray();
-      var neededFields = formAllFields.reduce(function (acc, field) {
-        if (field.name.includes("field")) {
-          return { ...acc, [field.name]: field.value };
-        } else {
-          return acc;
-        }
+      // Collect form values
+      var formFields = thisForm.serializeArray();
+      var knackFormatFields = formFields.reduce(function (acc, field) {
+        return { ...acc, [field.name]: field.value };
       }, {});
 
       // Start spinner
@@ -549,7 +545,7 @@ $(document).on("knack-view-render.view_466", function (event, view, data) {
           url: putUrl + recordId,
           type: "PUT",
           data: JSON.stringify({
-            ...neededFields, // Reason for cancellation and Remove from My Assignments fields from form
+            ...knackFormatFields, // Reason for cancellation and Remove from My Assignments fields from form
             [fields.assignedOfficerField]: appSpecifics.noOfficerAssignedId, // Add unassigned officer ID
             [fields.unassignedOfficerField]: userId, // Add current user as unassigned officer to track who cancelled
             [fields.addToMyAssignmentsField]: "No", // Add to My Assignments


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/3614

I touched a lot of code here, but the changes boil down to:

1. Updating jQuery selectors to specifically target elements within a Knack view id
2. Abstracting the custom table so that `requestRecords()` accepts parameters that define:
a. which columns to display in the table and the functions that get the data from records to display in cells
b. whether to add the time filter buttons or not
c. the function of the "Cancel My Sign Up" button (can now serve the purpose of sign up and cancel OR cancel only)
d. what filters apply to the Knack request for the `officer_assignment` records that populate the tables

These changes allow existing code to be reused to add the custom table logic to the "My Assignments" and "Future Assignments" in the "My Assignments" view.

#### My Assignments view with no assignments today but future assignments
<img width="979" alt="Screen Shot 2020-09-21 at 12 58 45 PM" src="https://user-images.githubusercontent.com/37249039/93805523-7c652800-fc0d-11ea-8beb-79bce89f6be6.png">

#### My Assignments view with both today assignments and future assignments
<img width="979" alt="Screen Shot 2020-09-21 at 1 02 20 PM" src="https://user-images.githubusercontent.com/37249039/93805540-8129dc00-fc0d-11ea-8960-141c73bbb8c7.png">

#### Cancellation modal that appears when cancelling from either table
<img width="979" alt="Screen Shot 2020-09-18 at 3 34 20 PM" src="https://user-images.githubusercontent.com/37249039/93805568-8dae3480-fc0d-11ea-86bc-02cc9255bef3.png">

