### PR TITLE
VZA | Update cancellation link and require checkbox

### DIFF
--- a/code/vza/vza.css
+++ b/code/vza/vza.css
@@ -11,7 +11,9 @@
 }
 
 /* Sign Up view - Available Assignments table scene_208 view_466 */
-#assignment-spinner {
+/* My Assignments view - Today's Assignments table scene_208 view_447 */
+/* My Assignments view - Future Assignments table scene_208 view_439 */
+.table-spinner {
   color: #023f74;
   font-size: 30px;
 }

--- a/code/vza/vza.js
+++ b/code/vza/vza.js
@@ -216,7 +216,7 @@ function requestRecords(filterConfig, view, tableConfig) {
 
   // Show spinner while fetching officer_assignment records
   $("#" + view + "> div.view-header").append(
-    `<span id="assignment-spinner" class="icon">&nbsp;<i class="fa fa-circle-o-notch fa-spin"></i></span>`
+    `<span id="${view}-table-spinner" class="table-spinner">&nbsp;<i class="fa fa-circle-o-notch fa-spin"></i></span>`
   );
 
   // Remove Knack generated table that we are replacing and request records
@@ -256,7 +256,7 @@ function requestRecords(filterConfig, view, tableConfig) {
       addCancelMyShiftButtonClickHandlers();
 
       // Remove spinner
-      $("#assignment-spinner").remove();
+      $("#" + view + "-table-spinner").remove();
     }
   });
 

--- a/code/vza/vza.js
+++ b/code/vza/vza.js
@@ -510,7 +510,7 @@ function requestRecords(filterConfig, view, tableConfig) {
     >
       <div class="kn-modal default" style="display: block">
         <header class="modal-card-head">
-          <h1 class="modal-card-title">Remove From Today's Assignments</h1>
+          <h1 class="modal-card-title">Remove From My Assignments</h1>
           <button class="delete close-cancellation-modal"></button>
         </header>
         <section class="modal-card-body kn-page-modal" id="kn-page-modal-0">

--- a/code/vza/vza.js
+++ b/code/vza/vza.js
@@ -239,7 +239,7 @@ function requestRecords(filterConfig, view, tableConfig) {
           .children()
           .remove();
         appendTableWithNoRecordsMessage();
-        $("#assignment-spinner").remove();
+        $("#" + view + "-table-spinner").remove();
         completeRecords = null;
         recordsInPage = null;
         return;

--- a/code/vza/vza.js
+++ b/code/vza/vza.js
@@ -552,6 +552,7 @@ function requestRecords(filterConfig, view, tableConfig) {
                             type="checkbox"
                             name="field_711"
                             value="Yes"
+                            required
                           />&nbsp;I have read the SEU Cancellation Policy and
                           understand that by cancelling this assignment with less
                           than 48 hours notice I am responsible for finding another
@@ -561,7 +562,8 @@ function requestRecords(filterConfig, view, tableConfig) {
                       </div>
                       <p class="kn-instructions">
                         <a
-                          href="https://docs.google.com/document/d/1cODXt1FuJVHAmiSg23hdcQDrfcFaiKhUmVOiFxgJ-4g/edit?usp=sharing"
+                          href="https://atd.knack.com/vza#cancellation-policy/"
+                          target="_blank"
                           >Cancellation Policy</a
                         >
                       </p>

--- a/code/vza/vza.js
+++ b/code/vza/vza.js
@@ -534,6 +534,7 @@ function requestRecords(filterConfig, view, tableConfig) {
                           name="field_671"
                           type="text"
                           value=""
+                          required
                         />
                       </div>
                       <p class="kn-instructions" style="display: none"></p>


### PR DESCRIPTION
Closes part of https://github.com/cityofaustin/atd-data-tech/issues/3965

This PR: 

1. Updates the modal cancellation form to require the checkbox
2. Fixes a bug where the selector for adding/removing spinners in the "My Assignments" page wasn't specific enough (code was creating two elements with the same id)
3. Makes the hard-coded cancellation modal title more general
4. Updates the cancellation policy link and behavior

#### Checkbox in Chrome 
<img width="500" alt="Screen Shot 2020-09-18 at 3 29 53 PM" src="https://user-images.githubusercontent.com/37249039/93809531-006dde80-fc13-11ea-8a7b-226e2cd3a3d3.png">

#### Checkbox on iPhone XR
<img width="285" alt="Screen Shot 2020-09-18 at 3 27 52 PM" src="https://user-images.githubusercontent.com/37249039/93809547-05329280-fc13-11ea-81eb-b5658927a3ad.png">

#### Updated modal title
<img width="722" alt="Screen Shot 2020-09-21 at 2 01 42 PM" src="https://user-images.githubusercontent.com/37249039/93809639-1f6c7080-fc13-11ea-80ec-7e0838b98df3.png">
