### PR TITLE
VZA | Improve time tracking usability

### DIFF
--- a/code/vza/README.md
+++ b/code/vza/README.md
@@ -1,6 +1,6 @@
-# Sign up / Available Assignments (scene_208)
+# Sign up / Available Assignments (scene_208) and Cancel My/Future Assignments (scene_180)
 
-## Custom table and sign up buttons (view_466)
+## Custom table and sign up/cancel buttons (view_466) and cancel-only buttons (view_439 and view_447)
 
 ### Create API view for fetching `officer_assignments`
 

--- a/code/vza/vza.css
+++ b/code/vza/vza.css
@@ -37,3 +37,7 @@
 .my-shift-button > span.icon > i {
   color: #af3c3c;
 }
+
+a.disabled > h2 > button {
+  opacity: 40%;
+}

--- a/code/vza/vza.js
+++ b/code/vza/vza.js
@@ -955,41 +955,29 @@ $(document).on("knack-view-render.view_439", function (event, view, data) {
 // The render event for this view triggers start and end button status updates
 function reloadAssignmentDetails() {
   Knack.views["view_448"].model.fetch();
-  console.log("had to reload");
 }
 
 function pollForElement(elementSelector, callback) {
-  var element = $(elementSelector);
+  var $element = $(elementSelector);
 
-  if (element === null) {
-    pollForButton(elementSelector, callback);
-  } else {
+  if (!$element[0]) {
     setTimeout(function () {
-      console.log("found button", element);
-      callback();
+      pollForElement(elementSelector, callback);
     }, 250);
+  } else {
+    callback();
   }
 }
 
 $(document).on("knack-view-render.view_449", function (event, view, data) {
-  reloadAssignmentDetails();
-});
+  // TODO: Look for start time in table and disable/add timestamp if necessary
+  var startTimeSpanSelector =
+    "#view_448 div.kn-detail.field_560 div.kn-detail-body";
 
-$(document).on("knack-view-render.view_450", function (event, view, data) {
-  reloadAssignmentDetails();
-});
-
-$(document).on("knack-view-render.view_448", function (event, view, data) {
-  var startTime = data.field_560;
-  var endTime = data.field_561;
-
-  // Disable button links based on assignment status
-  pollForElement(".view_449 a", function () {
+  pollForElement(startTimeSpanSelector, function () {
+    var $row = $(startTimeSpanSelector);
+    var startTime = $row[0].innerText;
     var startButtonLink = $(".view_449 a");
-
-    startButtonLink.click(function () {
-      startButtonLink.addClass("disabled");
-    });
 
     if (startTime.length !== 0) {
       startButtonLink.addClass("disabled");
@@ -998,19 +986,75 @@ $(document).on("knack-view-render.view_448", function (event, view, data) {
       );
     }
   });
+});
 
-  pollForElement(".view_450 a", function () {
-    var endButtonLink = $(".view_450 a");
-    // Add click handlers to disable buttons on click
-    endButtonLink.click(function () {
-      endButtonLink.addClass("disabled");
-    });
+$(document).on("knack-view-render.view_450", function (event, view, data) {
+  var endTimeSpanSelector =
+    "#view_448 div.kn-detail.field_561 div.kn-detail-body";
+  var endButtonLink = $(".view_450 a");
+
+  pollForElement(endTimeSpanSelector, function () {
+    var $row = $(endTimeSpanSelector);
+    var endTime = $row[0].innerText;
 
     if (endTime.length !== 0) {
       endButtonLink.addClass("disabled");
+    }
+
+    endTime.length !== 0 &&
       endButtonLink.append(
         `<div class="content status-timestamp"><strong>Assignment ended at ${endTime}</strong></div>`
       );
+  });
+
+  var startTimeSpanSelector =
+    "#view_448 div.kn-detail.field_560 div.kn-detail-body";
+
+  pollForElement(startTimeSpanSelector, function () {
+    var $row = $(startTimeSpanSelector);
+    var startTime = $row[0].innerText;
+    var startButtonLink = $(".view_449 a");
+
+    if (startTime.length === 0) {
+      endButtonLink.addClass("disabled");
     }
   });
 });
+
+// $(document).on("knack-view-render.view_448", function (event, view, data) {
+//   var startTime = data.field_560;
+//   var endTime = data.field_561;
+
+//   // Disable button links based on assignment status
+//   pollForElement(".view_449 a", function () {
+//     var startButtonLink = $(".view_449 a");
+
+//     startButtonLink.click(function () {
+//       startButtonLink.addClass("disabled");
+//     });
+
+//     if (startTime.length !== 0) {
+//       startButtonLink.addClass("disabled");
+//       startButtonLink.append(
+//         `<div class="content status-timestamp"><strong>Assignment started at ${startTime}</strong></div>`
+//       );
+//     }
+//   });
+
+//   pollForElement(".view_450 a", function () {
+//     var endButtonLink = $(".view_450 a");
+//     // Add click handlers to disable buttons on click
+//     endButtonLink.click(function () {
+//       endButtonLink.addClass("disabled");
+//     });
+
+//     if (endTime.length !== 0 || startTime.length === 0) {
+//       endButtonLink.addClass("disabled");
+//     }
+
+//     endTime.length !== 0 &&
+//       endButtonLink.append(
+//         `<div class="content status-timestamp"><strong>Assignment ended at ${endTime}</strong></div>`
+//       );
+//   });
+// });

--- a/code/vza/vza.js
+++ b/code/vza/vza.js
@@ -636,14 +636,14 @@ function requestRecords(filterConfig, view, tableConfig) {
             // Remove modal and stop spinner
             $("#kn-modal-bg-0").remove();
             $("#kn-loading-spinner").css("display", "none");
+
+            // If only cancelling, reload table to refresh user's assignments
+            if (tableConfig.isCancelOnly) {
+              requestRecords(filterConfig, view, tableConfig);
+            }
           }
         });
       });
-
-      // If only cancelling, reload table to refresh user's assignments
-      if (tableConfig.isCancelOnly) {
-        requestRecords(filterConfig, view, tableConfig);
-      }
     });
 
     // Add click handler to close modal (X) button
@@ -950,4 +950,67 @@ $(document).on("knack-view-render.view_439", function (event, view, data) {
     .ready(function () {
       requestRecords(filters.future, view.key, tableConfig);
     });
+});
+
+// The render event for this view triggers start and end button status updates
+function reloadAssignmentDetails() {
+  Knack.views["view_448"].model.fetch();
+  console.log("had to reload");
+}
+
+function pollForElement(elementSelector, callback) {
+  var element = $(elementSelector);
+
+  if (element === null) {
+    pollForButton(elementSelector, callback);
+  } else {
+    setTimeout(function () {
+      console.log("found button", element);
+      callback();
+    }, 250);
+  }
+}
+
+$(document).on("knack-view-render.view_449", function (event, view, data) {
+  reloadAssignmentDetails();
+});
+
+$(document).on("knack-view-render.view_450", function (event, view, data) {
+  reloadAssignmentDetails();
+});
+
+$(document).on("knack-view-render.view_448", function (event, view, data) {
+  var startTime = data.field_560;
+  var endTime = data.field_561;
+
+  // Disable button links based on assignment status
+  pollForElement(".view_449 a", function () {
+    var startButtonLink = $(".view_449 a");
+
+    startButtonLink.click(function () {
+      startButtonLink.addClass("disabled");
+    });
+
+    if (startTime.length !== 0) {
+      startButtonLink.addClass("disabled");
+      startButtonLink.append(
+        `<div class="content status-timestamp"><strong>Assignment started at ${startTime}</strong></div>`
+      );
+    }
+  });
+
+  pollForElement(".view_450 a", function () {
+    var endButtonLink = $(".view_450 a");
+    // Add click handlers to disable buttons on click
+    endButtonLink.click(function () {
+      endButtonLink.addClass("disabled");
+    });
+
+    if (endTime.length !== 0) {
+      endButtonLink.addClass("disabled");
+      endButtonLink.append(
+        `<div class="content status-timestamp"><strong>Assignment ended at ${endTime}</strong></div>`
+      );
+    }
+  });
 });

--- a/code/vza/vza.js
+++ b/code/vza/vza.js
@@ -927,7 +927,7 @@ $(document).on(
     var recordsTable = createRecordsTable(view.key, updatedTableConfig);
 
     // Append table, then request records and append shifts to table body
-    $("#view_447" + "> div.view-header")
+    $("#" + appSpecifics.todayAssignmentsView + "> div.view-header")
       .after(recordsTable)
       .ready(function () {
         requestRecords(filters.today, view.key, updatedTableConfig);

--- a/code/vza/vza.js
+++ b/code/vza/vza.js
@@ -11,9 +11,11 @@ var appSpecifics = {
   knackAppId: "5dc2ec50bbcb360016e338e1",
   apiTableScene: "scene_238", // Officer assignments table API scene
   apiTableView: "view_487", // Officer assignments table API view
-  availableAssignmentsView: "view_466", // Where to insert new table
-  startButtonView: "view_449",
-  endButtonView: "view_450",
+  availableAssignmentsView: "view_466", // Insert new table
+  todayAssignmentsView: "view_447", // Insert new table
+  futureAssignmentsView: "view_439", // Insert new table
+  startButtonView: "view_449", // Assignment Details view
+  endButtonView: "view_450", // Assignment Details view
   assignmentDetailsView: "view_448",
   noOfficerAssignedId: "5ebef4d0682bfc0015c9e0f4" // For conditional styles based on officer assigned
 };
@@ -30,7 +32,9 @@ var fields = {
   unassignedOfficerField: "field_669",
   addToMyAssignmentsField: "field_663",
   dateTimeOfCancellationField: "field_712",
-  assignmentStatus: "field_584"
+  assignmentStatus: "field_584",
+  startTime: "field_560",
+  endTime: "field_561"
 };
 
 // Get user auth for get request (API view is private) and set req headers
@@ -897,121 +901,107 @@ function addRecordLinkToTableConfig(view, config) {
   };
 }
 
-$(document).on("knack-view-render.view_447", function (event, view, data) {
-  var tableConfig = {
-    columns: {
-      Status: function (record) {
-        return record[fields.assignmentStatus];
+$(document).on(
+  "knack-view-render." + appSpecifics.todayAssignmentsView,
+  function (event, view, data) {
+    var tableConfig = {
+      columns: {
+        Status: function (record) {
+          return record[fields.assignmentStatus];
+        },
+        Time: function (record) {
+          return record[fields.timeField];
+        },
+        Sector: function (record) {
+          return record[fields.locationFieldRaw][0].identifier.split(" - ")[0];
+        },
+        Location: function (record) {
+          return record[fields.locationFieldRaw][0].identifier.split(" - ")[2];
+        }
       },
-      Time: function (record) {
-        return record[fields.timeField];
+      addTimeFilters: false,
+      isCancelOnly: true
+    };
+
+    var updatedTableConfig = addRecordLinkToTableConfig(view, tableConfig);
+    var recordsTable = createRecordsTable(view.key, updatedTableConfig);
+
+    // Append table, then request records and append shifts to table body
+    $("#view_447" + "> div.view-header")
+      .after(recordsTable)
+      .ready(function () {
+        requestRecords(filters.today, view.key, updatedTableConfig);
+      });
+  }
+);
+
+$(document).on(
+  "knack-view-render." + appSpecifics.futureAssignmentsView,
+  function (event, view, data) {
+    var tableConfig = {
+      columns: {
+        Time: function (record) {
+          return record[fields.timeField];
+        },
+        Sector: function (record) {
+          return record[fields.locationFieldRaw][0].identifier.split(" - ")[0];
+        },
+        Location: function (record) {
+          return record[fields.locationFieldRaw][0].identifier.split(" - ")[2];
+        }
       },
-      Sector: function (record) {
-        return record[fields.locationFieldRaw][0].identifier.split(" - ")[0];
-      },
-      Location: function (record) {
-        return record[fields.locationFieldRaw][0].identifier.split(" - ")[2];
-      }
-    },
-    addTimeFilters: false,
-    isCancelOnly: true
-  };
+      addTimeFilters: false,
+      isCancelOnly: true
+    };
 
-  var updatedTableConfig = addRecordLinkToTableConfig(view, tableConfig);
-  var recordsTable = createRecordsTable(view.key, updatedTableConfig);
+    var recordsTable = createRecordsTable(view.key, tableConfig);
 
-  // Append table, then request records and append shifts to table body
-  $("#view_447" + "> div.view-header")
-    .after(recordsTable)
-    .ready(function () {
-      requestRecords(filters.today, view.key, updatedTableConfig);
-    });
-});
-
-$(document).on("knack-view-render.view_439", function (event, view, data) {
-  var tableConfig = {
-    columns: {
-      Time: function (record) {
-        return record[fields.timeField];
-      },
-      Sector: function (record) {
-        return record[fields.locationFieldRaw][0].identifier.split(" - ")[0];
-      },
-      Location: function (record) {
-        return record[fields.locationFieldRaw][0].identifier.split(" - ")[2];
-      }
-    },
-    addTimeFilters: false,
-    isCancelOnly: true
-  };
-
-  var recordsTable = createRecordsTable(view.key, tableConfig);
-
-  // Append table, then request records and append shifts to table body
-  $("#" + view.key + "> div.view-header")
-    .after(recordsTable)
-    .ready(function () {
-      requestRecords(filters.future, view.key, tableConfig);
-    });
-});
+    // Append table, then request records and append shifts to table body
+    $("#" + view.key + "> div.view-header")
+      .after(recordsTable)
+      .ready(function () {
+        requestRecords(filters.future, view.key, tableConfig);
+      });
+  }
+);
 
 // Enable/disable Start and End assignment buttons and add timestamps
-var startTimeSpanSelector = `#${appSpecifics.assignmentDetailsView} div.kn-detail.field_560 div.kn-detail-body`;
-var endTimeSpanSelector = `#${appSpecifics.assignmentDetailsView} div.kn-detail.field_561 div.kn-detail-body`;
+var startTimeSpanSelector = `#${appSpecifics.assignmentDetailsView} div.kn-detail.${fields.startTime} div.kn-detail-body`;
+var endTimeSpanSelector = `#${appSpecifics.assignmentDetailsView} div.kn-detail.${fields.endTime} div.kn-detail-body`;
 
 function waitForAllEvents(listOfEvents, cb) {
-  //cb is a callback
-
-  var triggeredEvents = []; //create an array called triggered events
+  var triggeredEvents = [];
   listOfEvents.forEach(function (eventKey) {
-    //Looping through list of events
     var listener = function (event, view, record) {
-      //creating event listener
-
-      // $(document).off(eventKey, listener);
-      // removing that listener from the document
-      // this is for Safety / optimization (in case the page loads twice)
-
       if (!triggeredEvents.includes(eventKey)) {
-        triggeredEvents.push(eventKey); //add event to list of already triggered events
-        console.log(eventKey, triggeredEvents);
+        triggeredEvents.push(eventKey);
       }
 
       if (triggeredEvents.length === listOfEvents.length) {
-        //have all the events finished?
-        cb(); //run the callback
-        triggeredEvents = [];
+        cb();
+        triggeredEvents = []; // Clear out array and continue listening
       }
     };
+
     $(document).on(eventKey, listener);
   });
 }
 
+// When any of these views update, makes sure all three events occurred and then apply changes to button states
 waitForAllEvents(
   [
-    "knack-view-render.view_450",
-    "knack-view-render.view_449",
-    "knack-view-render.view_448"
+    "knack-view-render." + appSpecifics.assignmentDetailsView,
+    "knack-view-render." + appSpecifics.startButtonView,
+    "knack-view-render." + appSpecifics.endButtonView
   ],
   function () {
+    var $startTimeSpan = $(startTimeSpanSelector);
+    var startTime = $startTimeSpan[0].innerText;
+    var $startButtonLink = $(`.${appSpecifics.startButtonView} a`);
+
     var $endTimeSpan = $(endTimeSpanSelector);
     var endTime = $endTimeSpan[0].innerText;
     var $endButtonLink = $(`.${appSpecifics.endButtonView} a`);
-
-    var $startTimeSpan = $(startTimeSpanSelector);
-    var startTime = $startTimeSpan[0].innerText;
-    console.log(startTime);
-    var $startButtonLink = $(`.${appSpecifics.startButtonView} a`);
-
-    if (endTime.length !== 0) {
-      $endButtonLink.addClass("disabled");
-    }
-
-    endTime.length !== 0 &&
-      $(".end-timestamp").length === 0 &&
-      $endButtonLink.append(
-        `<div class="content end-timestamp"><strong>Assignment ended at ${endTime}</strong></div>`
-      );
 
     if (startTime.length !== 0) {
       $startButtonLink.addClass("disabled");
@@ -1019,10 +1009,16 @@ waitForAllEvents(
         $startButtonLink.append(
           `<div class="content start-timestamp"><strong>Assignment started at ${startTime}</strong></div>`
         );
+    } else if (startTime.length === 0) {
+      $endButtonLink.addClass("disabled");
     }
 
-    if (startTime.length === 0) {
+    if (endTime.length !== 0) {
       $endButtonLink.addClass("disabled");
+      $(".end-timestamp").length === 0 &&
+        $endButtonLink.append(
+          `<div class="content end-timestamp"><strong>Assignment ended at ${endTime}</strong></div>`
+        );
     }
   }
 );

--- a/code/vza/vza.js
+++ b/code/vza/vza.js
@@ -952,9 +952,9 @@ $(document).on("knack-view-render.view_439", function (event, view, data) {
     });
 });
 
-// The render event for this view triggers start and end button status updates
-function reloadAssignmentDetails() {
-  Knack.views["view_448"].model.fetch();
+// Enable/disable Start and End assignment buttons and add timestamps
+function reloadByViewId(viewId) {
+  Knack.views[viewId].model.fetch();
 }
 
 function pollForElement(elementSelector, callback) {
@@ -970,7 +970,6 @@ function pollForElement(elementSelector, callback) {
 }
 
 $(document).on("knack-view-render.view_449", function (event, view, data) {
-  // TODO: Look for start time in table and disable/add timestamp if necessary
   var startTimeSpanSelector =
     "#view_448 div.kn-detail.field_560 div.kn-detail-body";
 
@@ -978,6 +977,10 @@ $(document).on("knack-view-render.view_449", function (event, view, data) {
     var $row = $(startTimeSpanSelector);
     var startTime = $row[0].innerText;
     var startButtonLink = $(".view_449 a");
+
+    startButtonLink.click(function () {
+      reloadByViewId("view_450");
+    });
 
     if (startTime.length !== 0) {
       startButtonLink.addClass("disabled");
@@ -997,6 +1000,10 @@ $(document).on("knack-view-render.view_450", function (event, view, data) {
     var $row = $(endTimeSpanSelector);
     var endTime = $row[0].innerText;
 
+    endButtonLink.click(function () {
+      reloadByViewId("view_449");
+    });
+
     if (endTime.length !== 0) {
       endButtonLink.addClass("disabled");
     }
@@ -1013,48 +1020,9 @@ $(document).on("knack-view-render.view_450", function (event, view, data) {
   pollForElement(startTimeSpanSelector, function () {
     var $row = $(startTimeSpanSelector);
     var startTime = $row[0].innerText;
-    var startButtonLink = $(".view_449 a");
 
     if (startTime.length === 0) {
       endButtonLink.addClass("disabled");
     }
   });
 });
-
-// $(document).on("knack-view-render.view_448", function (event, view, data) {
-//   var startTime = data.field_560;
-//   var endTime = data.field_561;
-
-//   // Disable button links based on assignment status
-//   pollForElement(".view_449 a", function () {
-//     var startButtonLink = $(".view_449 a");
-
-//     startButtonLink.click(function () {
-//       startButtonLink.addClass("disabled");
-//     });
-
-//     if (startTime.length !== 0) {
-//       startButtonLink.addClass("disabled");
-//       startButtonLink.append(
-//         `<div class="content status-timestamp"><strong>Assignment started at ${startTime}</strong></div>`
-//       );
-//     }
-//   });
-
-//   pollForElement(".view_450 a", function () {
-//     var endButtonLink = $(".view_450 a");
-//     // Add click handlers to disable buttons on click
-//     endButtonLink.click(function () {
-//       endButtonLink.addClass("disabled");
-//     });
-
-//     if (endTime.length !== 0 || startTime.length === 0) {
-//       endButtonLink.addClass("disabled");
-//     }
-
-//     endTime.length !== 0 &&
-//       endButtonLink.append(
-//         `<div class="content status-timestamp"><strong>Assignment ended at ${endTime}</strong></div>`
-//       );
-//   });
-// });


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/3923

This PR adds conditional logic and timestamps to the start and end buttons in the "Assignment Details" view. The logic is carried out by `waitForAllEvents ()` which takes an argument of view render events and then fires code when all specified views have loaded. This allows updates in any of the three relevant views (start button, assignment details table, and end button) to set the buttons to the appropriate states and add timestamps if needed. These changes enable the following UI workflow:

1. Assignment is not started: Start button enabled and End button disabled
2. Assignment is started: Start button disabled with start timestamp and End button is enabled
3. Assignment is ended: Start button disabled with timestamp and End button disabled with timestamp

I also pulled some hardcoded view strings out into the `appSpecifics` config object.

### Assignment not started
<img width="521" alt="Screen Shot 2020-10-01 at 2 29 16 PM" src="https://user-images.githubusercontent.com/37249039/94854544-adeea800-03f2-11eb-9679-1c938fd87e3f.png">

### Assignment started
<img width="521" alt="Screen Shot 2020-10-01 at 2 29 44 PM" src="https://user-images.githubusercontent.com/37249039/94854548-b1822f00-03f2-11eb-9adb-6f0f301f56c9.png">

### Assignment ended
<img width="521" alt="Screen Shot 2020-10-01 at 2 29 54 PM" src="https://user-images.githubusercontent.com/37249039/94854555-b646e300-03f2-11eb-8cf7-d2278264cf37.png">
