### PR TITLE
VZA | Create template for COACD login

### DIFF
--- a/code/vza/vza.css
+++ b/code/vza/vza.css
@@ -41,3 +41,47 @@
 a.disabled > h2 > button {
   opacity: 40%;
 }
+
+/* Big Buttons */
+.big-button-container {
+  border-radius: 2px;
+  box-shadow: 0px 1px 2px 0px gray;
+  font-size: 2.5em;
+  padding: 10px;
+  margin: 20px;
+  max-width: 12em;
+}
+
+.big-button-container:hover {
+  background-color: #f7f7f7;
+  cursor: pointer;
+}
+
+.fa {
+  vertical-align: middle;
+}
+
+a.big-button {
+  text-decoration: none;
+}
+
+/* Small Buttons */
+.small-button-container {
+  padding: 5px;
+  margin: 20px;
+  border-radius: 2px;
+  box-shadow: 0px 1px 2px 0px gray;
+  font-size: 1em;
+  max-width: 15em;
+  background-color: #babbbc;
+  color: white;
+}
+
+.small-button-container:hover {
+  background-color: #4c4c4c;
+  cursor: pointer;
+}
+
+a.small-button {
+  text-decoration: none;
+}

--- a/code/vza/vza.js
+++ b/code/vza/vza.js
@@ -1054,10 +1054,11 @@ function customButton(
 }
 
 $(document).on("knack-view-render.any", function (event, page) {
-  // Find SSO button
+  // Find SSO button and existing custom button
   var $ssoButton = $(".kn-sso-container");
   var $coacdLoginDiv = $("#coacd-button-login");
 
+  // If SSO button exists on page and there isn't already a custom button
   if ($ssoButton.length && !$coacdLoginDiv.length) {
     var $ssoView = $ssoButton.closest("[id^=view_]");
     var viewId = $ssoView.get(0).id;
@@ -1076,33 +1077,34 @@ function customLoginButton(viewId) {
 
   var url = Knack.url_base + Knack.scene_hash + "auth/COACD";
 
-  // Create a custom button
+  // Create a div for Login buttons
   var $coacdButton = $("<div/>", {
     id: "coacd-button-login"
   });
-
-  // Append Big SSO Login button
   $coacdButton.appendTo("#" + viewId);
+
+  // Append Big SSO Login button and non-SSO Login button
   $coacdButton.append(
     "<a class='big-button' href='" +
       url +
       "'><div class='big-button-container'><span><i class='fa fa-sign-in'></i></span><span> Sign-in</span></div></a>"
   );
 
-  // customButton(
-  //   "caocd-button-login",
-  //   view_id,
-  //   url,
-  //   "sign-in",
-  //   "Sign-In",
-  //   "big-button",
-  //   "big-button-container"
-  // );
+  $coacdButton.append(
+    "<a class='small-button' href='javascript:void(0)'>" +
+      "<div class='small-button-container'><span><i class='fa fa-lock'></i></span><span> Non-COA Sign-In</span></div></a>"
+  );
+
+  // On non-SSO button click, hide SSO and non-SSO buttons and show Knack Login form
+  var $nonCoacdButton = $(".small-button");
+  $nonCoacdButton.click(function () {
+    console.log("You clicked the non-SSO button");
+  });
 
   // customButton(
   //   "non-coacd-button-login",
   //   view_id,
-  //   "javascript:void(0)",
+  //   "",
   //   "lock",
   //   "Non-COA Sign-In",
   //   "small-button",

--- a/code/vza/vza.js
+++ b/code/vza/vza.js
@@ -1060,15 +1060,7 @@ $(document).on("knack-view-render.any", function (event, page) {
   //  the views ojbect uses the view id of the login form element as each key
   //  and the page url of the login page's **chile page** as the value
   var views = {
-    view_39: "home",
-    view_5: "purchase-requests",
-    view_82: "purchasing-budget-review",
-    view_52: "account-administration",
-    view_322: "commodity-codes",
-    view_31: "reviews",
-    view_387: "invoice-details",
-    view_379: "add-invoice",
-    view_77: "my-purchase-requests"
+    view_39: "home"
   };
 
   if (page.key in views) {
@@ -1076,16 +1068,13 @@ $(document).on("knack-view-render.any", function (event, page) {
   }
 });
 
-function customLoginButton(view_id, page_name) {
-  //  special logic to generate URL and clean-up sign in page brefore creating large button
+function customLoginButton(view_id) {
+  // Remove Knack default SSO button, login form, and login title
   $(".kn-sso-container").hide();
-
   $(".login_form").hide();
-
   $("h2.kn-title").hide();
 
-  var url =
-    "https://atd.knack.com/finance-purchasing#" + page_name + "/auth/COACD";
+  var url = Knack.url_base + "/" + Knack.scene_hash + "auth/COACD";
 
   customButton(
     "caocd-button-login",

--- a/code/vza/vza.js
+++ b/code/vza/vza.js
@@ -1023,36 +1023,6 @@ waitForAllEvents(
   }
 );
 
-function customButton(
-  div_id,
-  view_id,
-  url,
-  fa_icon,
-  button_label,
-  button_class,
-  container_class,
-  callback
-) {
-  // Create a custom button
-  $("<div/>", {
-    id: div_id
-  }).appendTo("#" + view_id);
-
-  $("#" + div_id).append(
-    "<a class='" +
-      button_class +
-      "' href='" +
-      url +
-      "'><div class='" +
-      container_class +
-      "'><span><i class='fa fa-" +
-      fa_icon +
-      "'></i></span><span> " +
-      button_label +
-      "</span></div></a>"
-  );
-}
-
 $(document).on("knack-view-render.any", function (event, page) {
   // Find SSO button and existing custom button
   var $ssoButton = $(".kn-sso-container");
@@ -1063,13 +1033,11 @@ $(document).on("knack-view-render.any", function (event, page) {
     var $ssoView = $ssoButton.closest("[id^=view_]");
     var viewId = $ssoView.get(0).id;
 
-    customLoginButton(viewId);
-  } else {
-    console.log("No SSO button here!");
+    customizeLoginButton(viewId);
   }
 });
 
-function customLoginButton(viewId) {
+function customizeLoginButton(viewId) {
   // Hide Knack default SSO button, login form, login title, and any other children
   $("#" + viewId)
     .children()
@@ -1098,24 +1066,10 @@ function customLoginButton(viewId) {
   // On non-SSO button click, hide SSO and non-SSO buttons and show Knack Login form
   var $nonCoacdButton = $(".small-button");
   $nonCoacdButton.click(function () {
-    console.log("You clicked the non-SSO button");
+    $("#" + viewId)
+      .children()
+      .show();
+    $(".small-button-container,.big-button-container").hide();
+    $(".kn-sso-container").hide();
   });
-
-  // customButton(
-  //   "non-coacd-button-login",
-  //   view_id,
-  //   "",
-  //   "lock",
-  //   "Non-COA Sign-In",
-  //   "small-button",
-  //   "small-button-container",
-  //   function (divId = "non-coacd-button-login") {
-  //     setClickEvent(
-  //       divId,
-  //       showHideElements,
-  //       ".login_form",
-  //       ".small-button-container,.big-button-container"
-  //     );
-  //   }
-  // );
 }

--- a/code/vza/vza.js
+++ b/code/vza/vza.js
@@ -1022,3 +1022,96 @@ waitForAllEvents(
     }
   }
 );
+
+function customButton(
+  div_id,
+  view_id,
+  url,
+  fa_icon,
+  button_label,
+  button_class,
+  container_class,
+  callback
+) {
+  // Create a custom button
+  $("<div/>", {
+    id: div_id
+  }).appendTo("#" + view_id);
+
+  $("#" + div_id).append(
+    "<a class='" +
+      button_class +
+      "' href='" +
+      url +
+      "'><div class='" +
+      container_class +
+      "'><span><i class='fa fa-" +
+      fa_icon +
+      "'></i></span><span> " +
+      button_label +
+      "</span></div></a>"
+  );
+
+  if (callback) callback();
+}
+
+$(document).on("knack-view-render.any", function (event, page) {
+  //  wrapper to create large sign-in buttons
+  //  the views ojbect uses the view id of the login form element as each key
+  //  and the page url of the login page's **chile page** as the value
+  var views = {
+    view_39: "home",
+    view_5: "purchase-requests",
+    view_82: "purchasing-budget-review",
+    view_52: "account-administration",
+    view_322: "commodity-codes",
+    view_31: "reviews",
+    view_387: "invoice-details",
+    view_379: "add-invoice",
+    view_77: "my-purchase-requests"
+  };
+
+  if (page.key in views) {
+    customLoginButton(page.key, views[page.key]);
+  }
+});
+
+function customLoginButton(view_id, page_name) {
+  //  special logic to generate URL and clean-up sign in page brefore creating large button
+  $(".kn-sso-container").hide();
+
+  $(".login_form").hide();
+
+  $("h2.kn-title").hide();
+
+  var url =
+    "https://atd.knack.com/finance-purchasing#" + page_name + "/auth/COACD";
+
+  customButton(
+    "caocd-button-login",
+    view_id,
+    url,
+    "sign-in",
+    "Sign-In",
+    "big-button",
+    "big-button-container"
+  );
+
+  customButton(
+    "non-coacd-button-login",
+    view_id,
+    "javascript:void(0)",
+    "lock",
+    "Non-COA Sign-In",
+    "small-button",
+    "small-button-container",
+    function (divId = "non-coacd-button-login") {
+      setClickEvent(
+        divId,
+        showHideElements,
+        ".login_form",
+        ".small-button-container,.big-button-container"
+      );
+    }
+  );
+}

--- a/code/vza/vza.js
+++ b/code/vza/vza.js
@@ -1051,30 +1051,29 @@ function customButton(
       button_label +
       "</span></div></a>"
   );
-
-  if (callback) callback();
 }
 
 $(document).on("knack-view-render.any", function (event, page) {
-  //  wrapper to create large sign-in buttons
-  //  the views ojbect uses the view id of the login form element as each key
-  //  and the page url of the login page's **chile page** as the value
-  var views = {
-    view_39: "home"
-  };
+  // Find SSO button
+  var $ssoButton = $(".kn-sso-container");
 
-  if (page.key in views) {
-    customLoginButton(page.key, views[page.key]);
+  if ($ssoButton.length) {
+    var $ssoView = $ssoButton.closest("[id^=view_]");
+    var viewId = $ssoView.get(0).id;
+
+    customLoginButton(viewId);
+  } else {
+    console.log("No SSO button here!");
   }
 });
 
 function customLoginButton(view_id) {
-  // Remove Knack default SSO button, login form, and login title
+  // Hide Knack default SSO button, login form, and login title
   $(".kn-sso-container").hide();
   $(".login_form").hide();
   $("h2.kn-title").hide();
 
-  var url = Knack.url_base + "/" + Knack.scene_hash + "auth/COACD";
+  var url = Knack.url_base + Knack.scene_hash + "auth/COACD";
 
   customButton(
     "caocd-button-login",
@@ -1104,3 +1103,5 @@ function customLoginButton(view_id) {
     }
   );
 }
+
+// $(".kn-sso-container").closest("[id^=view_]")

--- a/code/vza/vza.js
+++ b/code/vza/vza.js
@@ -1056,8 +1056,9 @@ function customButton(
 $(document).on("knack-view-render.any", function (event, page) {
   // Find SSO button
   var $ssoButton = $(".kn-sso-container");
+  var $coacdLoginDiv = $("#coacd-button-login");
 
-  if ($ssoButton.length) {
+  if ($ssoButton.length && !$coacdLoginDiv.length) {
     var $ssoView = $ssoButton.closest("[id^=view_]");
     var viewId = $ssoView.get(0).id;
 
@@ -1067,41 +1068,52 @@ $(document).on("knack-view-render.any", function (event, page) {
   }
 });
 
-function customLoginButton(view_id) {
-  // Hide Knack default SSO button, login form, and login title
-  $(".kn-sso-container").hide();
-  $(".login_form").hide();
-  $("h2.kn-title").hide();
+function customLoginButton(viewId) {
+  // Hide Knack default SSO button, login form, login title, and any other children
+  $("#" + viewId)
+    .children()
+    .hide();
 
   var url = Knack.url_base + Knack.scene_hash + "auth/COACD";
 
-  customButton(
-    "caocd-button-login",
-    view_id,
-    url,
-    "sign-in",
-    "Sign-In",
-    "big-button",
-    "big-button-container"
+  // Create a custom button
+  var $coacdButton = $("<div/>", {
+    id: "coacd-button-login"
+  });
+
+  // Append Big SSO Login button
+  $coacdButton.appendTo("#" + viewId);
+  $coacdButton.append(
+    "<a class='big-button' href='" +
+      url +
+      "'><div class='big-button-container'><span><i class='fa fa-sign-in'></i></span><span> Sign-in</span></div></a>"
   );
 
-  customButton(
-    "non-coacd-button-login",
-    view_id,
-    "javascript:void(0)",
-    "lock",
-    "Non-COA Sign-In",
-    "small-button",
-    "small-button-container",
-    function (divId = "non-coacd-button-login") {
-      setClickEvent(
-        divId,
-        showHideElements,
-        ".login_form",
-        ".small-button-container,.big-button-container"
-      );
-    }
-  );
+  // customButton(
+  //   "caocd-button-login",
+  //   view_id,
+  //   url,
+  //   "sign-in",
+  //   "Sign-In",
+  //   "big-button",
+  //   "big-button-container"
+  // );
+
+  // customButton(
+  //   "non-coacd-button-login",
+  //   view_id,
+  //   "javascript:void(0)",
+  //   "lock",
+  //   "Non-COA Sign-In",
+  //   "small-button",
+  //   "small-button-container",
+  //   function (divId = "non-coacd-button-login") {
+  //     setClickEvent(
+  //       divId,
+  //       showHideElements,
+  //       ".login_form",
+  //       ".small-button-container,.big-button-container"
+  //     );
+  //   }
+  // );
 }
-
-// $(".kn-sso-container").closest("[id^=view_]")


### PR DESCRIPTION
Closes part of https://github.com/cityofaustin/atd-data-tech/issues/4390

This PR adds a view render handler that checks for the SSO button in any Knack view, finds the view ID it lives in, and then appends custom login buttons. The code uses the Knack object to build the SSO url. With these changes, this code can be added to any Knack app and ensures that any SSO button with class `kn-sso-container` will be replaced with the custom login buttons. 

This code is added in https://atd.knack.com/test-vision-zero-in-action-october-15-2020 and can be tested there.

![knackSSO](https://user-images.githubusercontent.com/37249039/98590002-c83e6000-2293-11eb-96c2-edbb9dc4d28b.gif)

