### PR TITLE
VZA | Limit Available Assignments to next four weeks

### DIFF
--- a/code/vza/vza.js
+++ b/code/vza/vza.js
@@ -253,9 +253,6 @@ function requestRecords(filterConfig, view, tableConfig) {
       recordsInPage = initializePagination(completeRecords);
       buildAndAppendShiftSection(recordsInPage);
       prependShiftTableWithPagination();
-      if (tableConfig.addTimeFilters) {
-        prependPaginationWithTimeFilters();
-      }
       addOpenShiftButtonClickHandlers();
       addCancelMyShiftButtonClickHandlers();
 
@@ -771,60 +768,6 @@ function requestRecords(filterConfig, view, tableConfig) {
     addPaginationClickHandlers("prev-arrow", "next-arrow");
   }
 
-  // Add time filters once, add click handlers to add filters to record request and handle active/inactive button status
-  function prependPaginationWithTimeFilters() {
-    if ($("#" + view + " #time-filter-buttons").length) {
-      return;
-    }
-
-    var filterMenu = `
-    <div class="js-filter-menu tabs is-toggle is-flush">
-      <ul id="time-filter-buttons">
-        <li class="is-active" id="all">
-          <a>
-            <span>All</span>
-          </a>
-        </li>
-        <li id="week">
-          <a>
-            <span>Next Week</span>
-          </a>
-        </li>
-        <li id="month">
-          <a>
-            <span>Next Month</span>
-          </a>
-          </li>
-      </ul>
-    </div>`;
-
-    $("#" + view + " .pagination-controls")
-      .before(filterMenu)
-      .ready(function () {
-        $("#" + view + " #time-filter-buttons")
-          .children()
-          .each(function () {
-            // Request records with matching time filter on click
-            $(this).click(function () {
-              var clickedFilterButtonId = $(this).attr("id");
-              requestRecords(filters[clickedFilterButtonId], view, tableConfig);
-
-              // Add/remove active button status
-              $("#" + view + " #time-filter-buttons")
-                .children()
-                .each(function () {
-                  var thisFilterButtonId = $(this).attr("id");
-                  if (thisFilterButtonId === clickedFilterButtonId) {
-                    $(this).addClass("is-active");
-                  } else {
-                    $(this).removeClass("is-active");
-                  }
-                });
-            });
-          });
-      });
-  }
-
   function appendTableWithNoRecordsMessage() {
     if ($("#" + view + "#no-records-msg").length) {
       return;
@@ -857,7 +800,6 @@ $(document).on("knack-view-render.view_466", function (event, view, data) {
         return record[fields.locationFieldRaw][0].identifier.split(" - ")[2];
       },
     },
-    addTimeFilters: false,
     isCancelOnly: false,
   };
 
@@ -919,7 +861,6 @@ $(document).on(
           return record[fields.observationsField];
         },
       },
-      addTimeFilters: false,
       isCancelOnly: true,
     };
 
@@ -950,7 +891,6 @@ $(document).on(
           return record[fields.locationFieldRaw][0].identifier.split(" - ")[2];
         },
       },
-      addTimeFilters: false,
       isCancelOnly: true,
     };
 

--- a/code/vza/vza.js
+++ b/code/vza/vza.js
@@ -56,10 +56,12 @@ var userId = Knack.getUserAttributes().id;
 
 // Filter for records for assignments time windows
 var filters = {
-  all: [
+  nextFourWeeks: [
     {
       field: fields.dateField,
-      operator: "is today or after",
+      operator: "is during the next",
+      type: "weeks",
+      range: "4",
     },
     {
       field: fields.assignmentDateTimeField,
@@ -86,25 +88,6 @@ var filters = {
       field: fields.assignedOfficerField,
       operator: "is",
       value: userId,
-    },
-  ],
-  week: [
-    {
-      value: "",
-      text: "Next Week",
-      operator: "is during the next",
-      field: fields.dateField,
-      type: "weeks",
-      range: "1",
-    },
-  ],
-  month: [
-    {
-      field: fields.dateField,
-      operator: "is during the next",
-      text: "Next Month",
-      type: "months",
-      range: "1",
     },
   ],
 };
@@ -809,7 +792,7 @@ $(document).on("knack-view-render.view_466", function (event, view, data) {
   $("#" + appSpecifics.availableAssignmentsView + "> div.view-header")
     .after(recordsTable)
     .ready(function () {
-      requestRecords(filters.all, view.key, tableConfig);
+      requestRecords(filters.nextFourWeeks, view.key, tableConfig);
     });
 });
 

--- a/code/vza/vza.js
+++ b/code/vza/vza.js
@@ -17,7 +17,7 @@ var appSpecifics = {
   startButtonView: "view_449", // Assignment Details view
   endButtonView: "view_450", // Assignment Details view
   noOfficerAssignedId: "5ebef4d0682bfc0015c9e0f4", // For conditional styles based on officer assigned
-  assignmentDetailsTimes: "view_538" // Assignment Details view
+  assignmentDetailsTimes: "view_538", // Assignment Details view
 };
 
 // officer_assignment object fields
@@ -35,7 +35,7 @@ var fields = {
   assignmentStatus: "field_584",
   startTime: "field_560",
   endTime: "field_561",
-  observationsField: "field_734"
+  observationsField: "field_734",
 };
 
 // Shared code
@@ -59,34 +59,34 @@ var filters = {
   all: [
     {
       field: fields.dateField,
-      operator: "is today or after"
+      operator: "is today or after",
     },
     {
       field: fields.assignmentDateTimeField,
-      operator: "is not blank"
-    }
+      operator: "is not blank",
+    },
   ],
   today: [
     {
       field: fields.dateField,
-      operator: "is today"
+      operator: "is today",
     },
     {
       field: fields.assignedOfficerField,
       operator: "is",
-      value: userId
-    }
+      value: userId,
+    },
   ],
   future: [
     {
       field: fields.dateField,
-      operator: "is after today"
+      operator: "is after today",
     },
     {
       field: fields.assignedOfficerField,
       operator: "is",
-      value: userId
-    }
+      value: userId,
+    },
   ],
   week: [
     {
@@ -95,8 +95,8 @@ var filters = {
       operator: "is during the next",
       field: fields.dateField,
       type: "weeks",
-      range: "1"
-    }
+      range: "1",
+    },
   ],
   month: [
     {
@@ -104,9 +104,9 @@ var filters = {
       operator: "is during the next",
       text: "Next Month",
       type: "months",
-      range: "1"
-    }
-  ]
+      range: "1",
+    },
+  ],
 };
 
 // Endpoints for officer_assignments API view
@@ -209,7 +209,7 @@ function requestRecords(filterConfig, view, tableConfig) {
   var headers = {
     "X-Knack-Application-ID": appSpecifics.knackAppId,
     Authorization: user,
-    "content-type": "application/json"
+    "content-type": "application/json",
   };
 
   var url =
@@ -261,7 +261,7 @@ function requestRecords(filterConfig, view, tableConfig) {
 
       // Remove spinner
       $("#" + view + "-table-spinner").remove();
-    }
+    },
   });
 
   // Helper functions that all need view arg to target correct table in view
@@ -486,14 +486,14 @@ function requestRecords(filterConfig, view, tableConfig) {
                 type: "PUT",
                 data: JSON.stringify({
                   action_link_index: 0,
-                  id: recordId
+                  id: recordId,
                 }),
                 headers: headers,
                 success: function (res) {
                   console.log(res);
-                }
+                },
               });
-            }
+            },
           });
         });
       });
@@ -616,7 +616,7 @@ function requestRecords(filterConfig, view, tableConfig) {
             [fields.assignedOfficerField]: appSpecifics.noOfficerAssignedId, // Add unassigned officer ID
             [fields.unassignedOfficerField]: userId, // Add current user as unassigned officer to track who cancelled
             [fields.addToMyAssignmentsField]: "No", // Add to My Assignments
-            [fields.dateTimeOfCancellationField]: now // DateTime of cancellation
+            [fields.dateTimeOfCancellationField]: now, // DateTime of cancellation
           }),
           headers: headers,
           success: function (res) {
@@ -645,7 +645,7 @@ function requestRecords(filterConfig, view, tableConfig) {
             if (tableConfig.isCancelOnly) {
               requestRecords(filterConfig, view, tableConfig);
             }
-          }
+          },
         });
       });
     });
@@ -855,10 +855,10 @@ $(document).on("knack-view-render.view_466", function (event, view, data) {
       },
       Location: function (record) {
         return record[fields.locationFieldRaw][0].identifier.split(" - ")[2];
-      }
+      },
     },
-    addTimeFilters: true,
-    isCancelOnly: false
+    addTimeFilters: false,
+    isCancelOnly: false,
   };
 
   var recordsTable = createRecordsTable(view.key, tableConfig);
@@ -894,7 +894,7 @@ function addRecordLinkToTableConfig(view, config) {
 
   return {
     ...config,
-    columns: { Details: createFolderIconLink, ...config.columns }
+    columns: { Details: createFolderIconLink, ...config.columns },
   };
 }
 
@@ -917,10 +917,10 @@ $(document).on(
         },
         Observations: function (record) {
           return record[fields.observationsField];
-        }
+        },
       },
       addTimeFilters: false,
-      isCancelOnly: true
+      isCancelOnly: true,
     };
 
     var updatedTableConfig = addRecordLinkToTableConfig(view, tableConfig);
@@ -948,10 +948,10 @@ $(document).on(
         },
         Location: function (record) {
           return record[fields.locationFieldRaw][0].identifier.split(" - ")[2];
-        }
+        },
       },
       addTimeFilters: false,
-      isCancelOnly: true
+      isCancelOnly: true,
     };
 
     var recordsTable = createRecordsTable(view.key, tableConfig);
@@ -992,7 +992,7 @@ waitForAllEvents(
   [
     "knack-view-render." + appSpecifics.assignmentDetailsTimes,
     "knack-view-render." + appSpecifics.startButtonView,
-    "knack-view-render." + appSpecifics.endButtonView
+    "knack-view-render." + appSpecifics.endButtonView,
   ],
   function () {
     var $startTimeInput = $(startTimeInputSelector);
@@ -1047,7 +1047,7 @@ function customizeLoginButton(viewId) {
 
   // Create a div for Login buttons
   var $coacdButton = $("<div/>", {
-    id: "coacd-button-login"
+    id: "coacd-button-login",
   });
   $coacdButton.appendTo("#" + viewId);
 

--- a/code/vza/vza.js
+++ b/code/vza/vza.js
@@ -56,18 +56,21 @@ var userId = Knack.getUserAttributes().id;
 
 // Filter for records for assignments time windows
 var filters = {
-  nextFourWeeks: [
-    {
-      field: fields.dateField,
-      operator: "is during the next",
-      type: "weeks",
-      range: "4",
-    },
-    {
-      field: fields.assignmentDateTimeField,
-      operator: "is not blank",
-    },
-  ],
+  nextFourWeeks: {
+    match: "or",
+    rules: [
+      {
+        field: fields.dateField,
+        operator: "is today",
+      },
+      {
+        field: fields.dateField,
+        operator: "is during the next",
+        range: 28,
+        type: "days",
+      },
+    ],
+  },
   today: [
     {
       field: fields.dateField,


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/4869

This PR removes the time filter UI from the "Available Assignments" view and also sets the default time filter for officer assignments records to only show those in the next four weeks. Prettier made some formatting changes so happy to talk through the important parts.

### Before
<img width="1198" alt="Screen Shot 2021-01-13 at 5 50 59 PM" src="https://user-images.githubusercontent.com/37249039/104526459-0fb0d780-55c8-11eb-82c3-42b85aac6373.png">

### After
<img width="1198" alt="Screen Shot 2021-01-13 at 5 46 17 PM" src="https://user-images.githubusercontent.com/37249039/104526334-b6e13f00-55c7-11eb-9e0e-1b473cc3a3f9.png">
