### PR TITLE
One-officer assignments are not displaying in the "All Assignments" page

### DIFF
--- a/code/vza/README.md
+++ b/code/vza/README.md
@@ -117,6 +117,7 @@ To group officer assignments into shifts, there are two steps executed in the cu
 - Start Time
 - End Time
 - Number of Observations
+- Child Record Number
 - Send email action **(this column is setup in Step 4)**
 
 ![API view columns](images/api_view_columns.png)

--- a/code/vza/vza.js
+++ b/code/vza/vza.js
@@ -135,7 +135,10 @@ function groupRecordsIntoAssignments(records) {
     var record = records[i];
     var officerShift = record[fields.officerShiftField];
 
-    if (groupedRecords[officerShift]) {
+    // First check if this is a single officer assignment
+    if (record[fields.childRecordNumberField] === "1") {
+      groupedRecords[officerShift + "- Single"] = [record];
+    } else if (groupedRecords[officerShift]) {
       groupedRecords[officerShift].push(record);
     } else {
       groupedRecords[officerShift] = [record];

--- a/code/vza/vza.js
+++ b/code/vza/vza.js
@@ -36,6 +36,7 @@ var fields = {
   startTime: "field_560",
   endTime: "field_561",
   observationsField: "field_734",
+  childRecordNumberField: "field_666",
 };
 
 // Shared code


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/5213

This PR for VZA adds support for creating officer assignment sign up buttons from single officer assignments. Originally, the VZA process only created sets of `officer_assignments` that were intended for sign up by multiple officers. This change takes assignments that only have a single child `officer_assigment` record associated with them and groups them away multi-officer assignments. 

By initially grouping these special assignments into separate arrays, the rest of the code that sorts `officer_assigments` into replicates that are associated with the UI buttons works as expected.

What broke:
```
 [D,A,A,B,B,C,C] => Breaks when no match for D is found
```
The fix (pre-sort single records out first):
```
[D] => [[D]]
[A,A,B,B,C,C] => [[A,B,C], [A,B,C]]
```
