### PR TITLE
5551 - remove lat/long fields after form submits

### DIFF
--- a/code/signs-markings/signs-markings.js
+++ b/code/signs-markings/signs-markings.js
@@ -327,6 +327,8 @@ $(document).on("knack-view-render.view_2607", function(event, scene) {
   if ($("#lat-lon-form .view-header").length !== 0) {
     $("#lat-lon-form .view-header").remove();
   }
+  // Hide Latitude/Longitude fields and labels overlaying map
+  $("#kn-input-field_3300 > div").hide();
 });
 
 // END: Knack Geo Location Selector Plugin


### PR DESCRIPTION
Fixes https://github.com/cityofaustin/atd-data-tech/issues/5551

After the form to add a new location was submitted, the latitude/longitude fields reappear. This hides the fields when the view refreshes.

Fix deployed in test app: https://atd.knack.com/test-smb-17-mar-2021-signs-and-markings-operations#work-order-signs/view-work-orders-details-sign/6052518fb22062066e5be47e/