### PR TITLE
Update custom SSO button and big button to complement each other

### DIFF
--- a/code/common/big-button/big-button.css
+++ b/code/common/big-button/big-button.css
@@ -1,3 +1,6 @@
+/***************************************/
+/************* Big Buttons *************/
+/***************************************/
 .big-button-container {
   border-radius: 2px;
   box-shadow: 0px 1px 2px 0px gray;

--- a/code/common/big-button/big-button.js
+++ b/code/common/big-button/big-button.js
@@ -34,39 +34,3 @@ function bigButton(
 
   if (callback) callback();
 }
-
-// Some examples
-
-//>>>HOME TAB BUTTONS
-$(document).on("knack-view-render.view_15", function (event, page) {
-  // create large button on the home page
-  bigButton(
-    "development-reviews",
-    "view_15",
-    "https://atd.knack.com/development-services#home/development-reviews/",
-    "list-ul",
-    "Development Reviews"
-  );
-});
-
-$(document).on("knack-view-render.view_55", function (event, page) {
-  // create large button on the home page
-  bigButton(
-    "my-reviews",
-    "view_55",
-    "https://atd.knack.com/development-services#my-reviews/",
-    "male",
-    "My Reviews"
-  );
-});
-
-$(document).on("knack-view-render.view_15", function (event, page) {
-  // create large button on the home page
-  bigButton(
-    "development-reviews",
-    "view_15",
-    "https://atd.knack.com/development-services#home/development-reviews/",
-    "list-ul",
-    "Development Reviews"
-  );
-});

--- a/code/common/custom-login-button/custom-login-button.css
+++ b/code/common/custom-login-button/custom-login-button.css
@@ -1,27 +1,6 @@
-/* Big Buttons */
-.big-button-container {
-  border-radius: 2px;
-  box-shadow: 0px 1px 2px 0px gray;
-  font-size: 2.5em;
-  padding: 10px;
-  margin: 20px;
-  max-width: 12em;
-}
-
-.big-button-container:hover {
-  background-color: #f7f7f7;
-  cursor: pointer;
-}
-
-.fa {
-  vertical-align: middle;
-}
-
-a.big-button {
-  text-decoration: none;
-}
-
-/* Small Buttons */
+/***************************************/
+/************* Small Buttons *************/
+/***************************************/
 .small-button-container {
   padding: 5px;
   margin: 20px;

--- a/code/common/custom-login-button/custom-login-button.js
+++ b/code/common/custom-login-button/custom-login-button.js
@@ -17,11 +17,7 @@ function customizeLoginButton(viewId) {
   $coacdButton.appendTo("#" + viewId);
 
   // Append Big SSO Login button and non-SSO Login button
-  $coacdButton.append(
-    "<a class='big-button' href='" +
-      url +
-      "'><div class='big-button-container'><span><i class='fa fa-sign-in'></i></span><span> Sign-in</span></div></a>"
-  );
+  bigButton("coacd-big-button", "coacd-button-login", url, "sign-in", "Sign-In")
 
   $coacdButton.append(
     "<a class='small-button' href='javascript:void(0)'>" +


### PR DESCRIPTION
This PR patches the updated custom SSO button code and big button code to rely on each other. This will allow common CSS to target both the SSO buttons and the big buttons to fix the bug where underline text decoration and a clickable right margin would occur. I'll be updating the docs to reflect the update.

I also removed the examples from the JS code that I originally included. There is an example in GitBook, and I only confused myself with them about whether they were needed in the Knack app or not. 😅 

### Demo in Signs and Markings
![signsAndMarkings](https://user-images.githubusercontent.com/37249039/114949779-54424e00-9e17-11eb-9830-bd01da93fa37.gif)
