### PR TITLE
[TDS] Update JS to not hide Pro Rata Share % on Improvement Selection

### DIFF
--- a/code/transportation-development-services/tds.js
+++ b/code/transportation-development-services/tds.js
@@ -427,9 +427,11 @@ $(document).on("knack-view-render.view_628", function (event, view) {
   // Attach event listener to handle change in field_495 select (Improvement)
   $("#view_628-field_495").on("change", function (event) {
     var fieldValue = event.target.value;
+    var mitigationType = $("#view_509-field_326").val();
 
     hideFormFields("view_628");
     showFormFieldsByValue(fieldValue);
+    showFormFieldsByMitigationType(mitigationType);
   });
 });
 

--- a/code/transportation-development-services/tds.js
+++ b/code/transportation-development-services/tds.js
@@ -406,7 +406,7 @@ function hideFormFields(fieldViewId) {
   });
 }
 
-function showFormFieldsByValue(value) {
+function showFormFieldsByImprovementType(value) {
   // Un-hide form fields in map
   if(fieldsIdsShownOnImprovementSelect.hasOwnProperty(value)){
   	fieldsIdsShownOnImprovementSelect[value].forEach(function (fieldId) {
@@ -429,7 +429,7 @@ function showFieldsByImprovementAndType(viewId){
   var mitigationType = $("#" + viewId + "-field_326").val();
 
   hideFormFields(viewId);
-  showFormFieldsByValue(improvementType);
+  showFormFieldsByImprovementType(improvementType);
   showFormFieldsByMitigationType(mitigationType);
 }
 
@@ -457,7 +457,7 @@ $(document).on("knack-view-render.view_509", function (event, view) {
   
   // If there is an existing value, show associated fields
   if(fieldsIdsShownOnImprovementSelect.hasOwnProperty(improvementValue)){	
-     showFormFieldsByValue(improvementValue);
+     showFormFieldsByImprovementType(improvementValue);
   }
   
   // If there is an existing value, show associated fields

--- a/code/transportation-development-services/tds.js
+++ b/code/transportation-development-services/tds.js
@@ -408,39 +408,52 @@ function hideFormFields(fieldViewId) {
 
 function showFormFieldsByValue(value) {
   // Un-hide form fields in map
-  fieldsIdsShownOnImprovementSelect[value].forEach(function (fieldId) {
-    $("#" + fieldId).show();
-  });
+  if(fieldsIdsShownOnImprovementSelect.hasOwnProperty(value)){
+  	fieldsIdsShownOnImprovementSelect[value].forEach(function (fieldId) {
+    	$("#" + fieldId).show();
+  	});
+  }
 }
 
 function showFormFieldsByMitigationType(value) {
   // Un-hide form fields in map
-  fieldsIdsShownOnMitigationTypeSelect[value].forEach(function (fieldId) {
-    $("#" + fieldId).show();
-  });
+  if(fieldsIdsShownOnMitigationTypeSelect.hasOwnProperty(value)){
+  	fieldsIdsShownOnMitigationTypeSelect[value].forEach(function (fieldId) {
+    	$("#" + fieldId).show();
+  	});
+  }
+}
+
+function showFieldsByImprovementAndType(viewId){
+  var improvementType = $("#" + viewId + "-field_495").val();
+  var mitigationType = $("#" + viewId + "-field_326").val();
+
+  hideFormFields(viewId);
+  showFormFieldsByValue(improvementType);
+  showFormFieldsByMitigationType(mitigationType);
 }
 
 //the Add Mitigation Form
 $(document).on("knack-view-render.view_628", function (event, view) {
-  hideFormFields("view_628");
+  hideFormFields(view.key);
 
   // Attach event listener to handle change in field_495 select (Improvement)
   $("#view_628-field_495").on("change", function (event) {
-    var fieldValue = event.target.value;
-    var mitigationType = $("#view_509-field_326").val();
+    showFieldsByImprovementAndType(view.key);
+  });
 
-    hideFormFields("view_628");
-    showFormFieldsByValue(fieldValue);
-    showFormFieldsByMitigationType(mitigationType);
+  // Attach event listener to handle change in field_326 select (Mitigation Type)
+  $("#view_628-field_326").on("change", function (event) {
+    showFieldsByImprovementAndType(view.key);
   });
 });
 
 //the Edit Mitigation Form
 $(document).on("knack-view-render.view_509", function (event, view) {
-  hideFormFields("view_509");
+  hideFormFields(view.key);
   
-  var improvementValue = $("#view_509-field_495").val();
-  var mitigationType = $("#view_509-field_326").val();
+  var improvementValue = $("#" + view.key +"-field_495").val();
+  var mitigationType = $("#" + view.key +"-field_326").val();
   
   // If there is an existing value, show associated fields
   if(fieldsIdsShownOnImprovementSelect.hasOwnProperty(improvementValue)){	
@@ -453,13 +466,13 @@ $(document).on("knack-view-render.view_509", function (event, view) {
   }
 
   // Attach event listener to handle change in field_495 select (Improvement)
-  $("#view_509-field_495").on("change", function (event) {
-    var fieldValue = event.target.value;
-    var mitigationType = $("#view_509-field_326").val();
+  $("#" + view.key + "-field_495").on("change", function (event) {
+    showFieldsByImprovementAndType(view.key);
+  });
 
-    hideFormFields("view_509");
-    showFormFieldsByValue(fieldValue);
-    showFormFieldsByMitigationType(mitigationType);
+  // Attach event listener to handle change in field_326 select (Mitigation Type)
+  $("#" + view.key + "-field_326").on("change", function (event) {
+    showFieldsByImprovementAndType(view.key);
   });
 });
 

--- a/code/transportation-development-services/tds.js
+++ b/code/transportation-development-services/tds.js
@@ -445,11 +445,13 @@ $(document).on("knack-view-render.view_509", function (event, view) {
   // If there is an existing value, show associated fields
   if(fieldsIdsShownOnFieldSelect.hasOwnProperty(improvementValue)){	
      showFormFieldsByValue(improvementValue);
+     showFormFieldsByMitigationType(mitigationType);
   }
 
   // Attach event listener to handle change in field_495 select (Improvement)
   $("#view_509-field_495").on("change", function (event) {
     var fieldValue = event.target.value;
+    var mitigationType = $("#view_509-field_326").val();
 
     hideFormFields("view_509");
     showFormFieldsByValue(fieldValue);

--- a/code/transportation-development-services/tds.js
+++ b/code/transportation-development-services/tds.js
@@ -324,7 +324,7 @@ var fieldsIdsShownOnLoad = {
   "kn-input-field_211": "Recommendation Notes",
 };
 
-var fieldsIdsShownOnFieldSelect = {
+var fieldsIdsShownOnImprovementSelect = {
   // "MC Field Value": [...ids of fields to show on value select]
   "Construct Turn Lane": [
     "kn-input-field_494",
@@ -389,6 +389,11 @@ var fieldsIdsShownOnFieldSelect = {
   ],
 };
 
+var fieldsIdsShownOnMitigationTypeSelect = {
+  // "MC Field Value": [...ids of fields to show on value select]
+  "Mitigation Fee in Lieu": ["kn-input-field_488"]
+};
+
 function hideFormFields(fieldViewId) {
   var $fields = $("#" + fieldViewId).find(".kn-input");
 
@@ -403,7 +408,14 @@ function hideFormFields(fieldViewId) {
 
 function showFormFieldsByValue(value) {
   // Un-hide form fields in map
-  fieldsIdsShownOnFieldSelect[value].forEach(function (fieldId) {
+  fieldsIdsShownOnImprovementSelect[value].forEach(function (fieldId) {
+    $("#" + fieldId).show();
+  });
+}
+
+function showFormFieldsByMitigationType(value) {
+  // Un-hide form fields in map
+  fieldsIdsShownOnMitigationTypeSelect[value].forEach(function (fieldId) {
     $("#" + fieldId).show();
   });
 }
@@ -426,6 +438,7 @@ $(document).on("knack-view-render.view_509", function (event, view) {
   hideFormFields("view_509");
   
   var improvementValue = $("#view_509-field_495").val();
+  var mitigationType = $("#view_509-field_326").val();
   
   // If there is an existing value, show associated fields
   if(fieldsIdsShownOnFieldSelect.hasOwnProperty(improvementValue)){	
@@ -438,6 +451,7 @@ $(document).on("knack-view-render.view_509", function (event, view) {
 
     hideFormFields("view_509");
     showFormFieldsByValue(fieldValue);
+    showFormFieldsByMitigationType(mitigationType);
   });
 });
 

--- a/code/transportation-development-services/tds.js
+++ b/code/transportation-development-services/tds.js
@@ -443,8 +443,12 @@ $(document).on("knack-view-render.view_509", function (event, view) {
   var mitigationType = $("#view_509-field_326").val();
   
   // If there is an existing value, show associated fields
-  if(fieldsIdsShownOnFieldSelect.hasOwnProperty(improvementValue)){	
+  if(fieldsIdsShownOnImprovementSelect.hasOwnProperty(improvementValue)){	
      showFormFieldsByValue(improvementValue);
+  }
+  
+  // If there is an existing value, show associated fields
+  if(fieldsIdsShownOnMitigationTypeSelect.hasOwnProperty(mitigationType)){	
      showFormFieldsByMitigationType(mitigationType);
   }
 

--- a/code/transportation-development-services/tds.js
+++ b/code/transportation-development-services/tds.js
@@ -315,6 +315,9 @@ Highcharts.setOptions({
 /****************************************************/
 /**** Hide/Show TIA Add Mitigation form elements ****/
 /****************************************************/
+var improvementField = "field_495";
+var mitigationField = "field_326";
+
 var fieldsIdsShownOnLoad = {
   // "Field ID": "Field Name"
   "kn-input-field_639": "Mitigation Location",
@@ -425,8 +428,8 @@ function showFormFieldsByMitigationType(value) {
 }
 
 function showFieldsByImprovementAndType(viewId){
-  var improvementType = $("#" + viewId + "-field_495").val();
-  var mitigationType = $("#" + viewId + "-field_326").val();
+  var improvementType = $("#" + viewId + "-" + improvementField).val();
+  var mitigationType = $("#" + viewId + "-" + mitigationField).val();
 
   hideFormFields(viewId);
   showFormFieldsByImprovementType(improvementType);
@@ -438,12 +441,12 @@ $(document).on("knack-view-render.view_628", function (event, view) {
   hideFormFields(view.key);
 
   // Attach event listener to handle change in field_495 select (Improvement)
-  $("#view_628-field_495").on("change", function (event) {
+  $("#" + view.key + "-" + improvementField).on("change", function (event) {
     showFieldsByImprovementAndType(view.key);
   });
 
   // Attach event listener to handle change in field_326 select (Mitigation Type)
-  $("#view_628-field_326").on("change", function (event) {
+  $("#" + view.key + "-" + mitigationField).on("change", function (event) {
     showFieldsByImprovementAndType(view.key);
   });
 });
@@ -452,8 +455,8 @@ $(document).on("knack-view-render.view_628", function (event, view) {
 $(document).on("knack-view-render.view_509", function (event, view) {
   hideFormFields(view.key);
   
-  var improvementValue = $("#" + view.key +"-field_495").val();
-  var mitigationType = $("#" + view.key +"-field_326").val();
+  var improvementValue = $("#" + view.key + "-" + improvementField).val();
+  var mitigationType = $("#" + view.key + "-" + mitigationField).val();
   
   // If there is an existing value, show associated fields
   if(fieldsIdsShownOnImprovementSelect.hasOwnProperty(improvementValue)){	
@@ -466,12 +469,12 @@ $(document).on("knack-view-render.view_509", function (event, view) {
   }
 
   // Attach event listener to handle change in field_495 select (Improvement)
-  $("#" + view.key + "-field_495").on("change", function (event) {
+  $("#" + view.key + "-" + improvementField).on("change", function (event) {
     showFieldsByImprovementAndType(view.key);
   });
 
   // Attach event listener to handle change in field_326 select (Mitigation Type)
-  $("#" + view.key + "-field_326").on("change", function (event) {
+  $("#" + view.key + "-" + mitigationField).on("change", function (event) {
     showFieldsByImprovementAndType(view.key);
   });
 });


### PR DESCRIPTION
This PR updates the custom code that updates fields present in the Mitigation add and edit forms in the TIA module (https://github.com/cityofaustin/atd-data-tech/issues/5811). The form will now show the Pro Rata % field if "Mitigation Fee in Lieu" is chosen in the Mitigation Type dropdown.

The add and edit forms can be tested in the TDS backup at https://atd.knack.com/tds--transportation-development-services-portal--backup--14-apr-2021#tia-mitigations-directory/tia-mitigation-details/607766d886a1e30676ce819c/

#### Demo
![mitigationFormImprovements](https://user-images.githubusercontent.com/37249039/115474595-62bbab80-a203-11eb-9791-9cb5eab68d2b.gif)
