### PR TITLE
6586 - mobile menu for TIA

### DIFF
--- a/code/transportation-development-services/tds.css
+++ b/code/transportation-development-services/tds.css
@@ -771,7 +771,6 @@ a.form-link:hover {text-decoration:underline;}
 .tia-button a {
   padding: .5em;
   color: #163f6e;
-  line-height: 32px;
   text-decoration: none;
   display: block;
 }

--- a/code/transportation-development-services/tds.css
+++ b/code/transportation-development-services/tds.css
@@ -773,10 +773,11 @@ a.form-link:hover {text-decoration:underline;}
   color: #163f6e;
   line-height: 32px;
   text-decoration: none;
+  display: block;
 }
 
 .tia-button .icon {
-  line-height: 28px;
+  vertical-align: baseline;
 }
 
 /**********************************/

--- a/code/transportation-development-services/tds.css
+++ b/code/transportation-development-services/tds.css
@@ -668,17 +668,6 @@ a.form-link:hover {text-decoration:underline;}
   }
 }
 
-/******************************************/
-/*** Custom TIA Menu Buttons Navigation ***/
-/******************************************/
-
-/* hide custom menu if on mobile */
-@media (max-width: 799px) {
-  #tia-menu-list {
-    display: none;
-  }
-}
-
 /* hide knack menu buttons if on desktop */
 @media (min-width: 799px) {
   #view_163 {
@@ -712,6 +701,82 @@ a.form-link:hover {text-decoration:underline;}
 
 .tia-dropdown-menu-list li:hover {
   background-color: rgb(235,235,235);
+}
+
+/*
+  Styling for TIA dropdown menu on mobile
+*/
+@media (min-width: 799px) {
+  .mobile-details-dropdown-menu {
+    display: none;
+  }
+}
+
+.mobile-details-dropdown-menu ul {
+  margin-left: .25em;
+}
+
+#tia-mobile-menu-list {
+  list-style-type: none;
+  margin: 0;
+} 
+
+#tia-mobile-menu-list ul {
+  list-style-type: none;
+}
+
+.tia-mobile-dropdown-menu span {
+  margin-top: .25em;
+}
+
+.mobile-dropdown-button {
+  display: flex;
+}
+
+.mobile-dropdown-button i {
+  display: none;
+}
+
+.mobile-dropdown-button.show-icon i {
+  display: inherit;
+  width: 16px;
+}
+
+.mobile-dropdown-button:not(.show-icon)::before {
+  content: "\203A";
+  font-size: 18px;
+  font-weight: 800;
+  width: 16px;
+  line-height: 16px;
+}
+
+.tia-dropdown-menu-list {
+  margin-top: 1em;
+  display: none;
+}
+
+.tia-dropdown-menu-list.active {
+  display: inherit;
+}
+
+.tia-button {
+  background-color: rgba(0,0,0,.08);
+  color: #163f6e;
+  font-size: 1.1em;
+  padding: .4em .8em;
+  height: 32px;
+  border-radius: .35em
+}
+
+.tia-button a {
+  padding: .5em;
+  color: #163f6e;
+  line-height: 32px;
+  text-decoration: none;
+}
+
+.tia-button .icon {
+  line-height: 28px;
 }
 
 /**********************************/

--- a/code/transportation-development-services/tds.js
+++ b/code/transportation-development-services/tds.js
@@ -567,10 +567,11 @@ $(document).on("knack-view-render.view_321", function (event, page) {
 /**** TIA Menu Buttons Navigation ****/
 /*************************************/
 
-function dropdownMenuItem(recordId, route, iconName, linkName, newTab = false) {
+function dropdownMenuItem(recordId, route, iconName, linkName, newTab = false, mobile=false) {
+  const buttonClass = mobile ? "tia-button" : "kn-button";
   if (newTab) {
     return (
-      `<li class="kn-button">\
+      `<li class="${buttonClass}">\
         <a href="#tia-requests/tia-case-details/${recordId}/${route}/${recordId}" target="_blank" and rel="noopener noreferrer">\
           <span class="icon is-small"> \
             <i class="fa ${iconName}" /> \
@@ -580,7 +581,7 @@ function dropdownMenuItem(recordId, route, iconName, linkName, newTab = false) {
       </li>`)
   }
   return (
-    `<li class="kn-button">\
+    `<li class="${buttonClass}">\
       <a href="#tia-requests/tia-case-details/${recordId}/${route}/${recordId}">\
         <span class="icon is-small"> \
           <i class="fa ${iconName}" /> \
@@ -589,6 +590,14 @@ function dropdownMenuItem(recordId, route, iconName, linkName, newTab = false) {
       </a>\
     </li>`)
 }
+
+// Function to toggle "active" and "show-icon" classes for mobile dropdown menu
+// if class is not "active", list is display: none;
+$(document).on('click', '.mobile-dropdown-button', function(event) {
+  const menuList = $(event.target).siblings()[0]
+  $(menuList).toggleClass("active")
+  $(event.target).toggleClass("show-icon")
+});
 
 /* Case Details Page */
 $(document).on('knack-view-render.view_744', function(event, view, record) {
@@ -623,6 +632,39 @@ $(document).on('knack-view-render.view_744', function(event, view, record) {
       </li>\
       ${dropdownMenuItem(recordId, "edit-tia-fee-status-reviewer", "fa-dollar", "Fees")}\
       ${dropdownMenuItem(recordId, "add-tia-communication", "fa-plus-circle", "Communication")}\
+    </ul>\
+  </div>`).appendTo("#view_744")
+
+  // *** Dropdown menu for mobile views ***
+  $(`<div class="mobile-details-dropdown-menu">\
+    <ul id="tia-mobile-menu-list">\
+      <li class="tia-mobile-dropdown-menu">\
+        <span class="tia-button mobile-dropdown-button"> \
+          <i class="fa fa-angle-down tia-dropdown" /> \
+          Case Management Menu\
+        </span>\
+        <ul class="tia-dropdown-menu-list" style="min-width: 152px; margin: .5em;">\
+          ${dropdownMenuItem(recordId, "tia-case-details", "fa-list-alt", "Case Details", false, true)}\
+          ${dropdownMenuItem(recordId, "tia-case-management", "fa-archive", "Scope & Submissions", false, true)}\
+          ${dropdownMenuItem(recordId, "tia-mitigation-details", "fa-file-text-o", "Mitigations", false, true)}\
+          ${dropdownMenuItem(recordId, "memo-builder", "fa-medium", "Memo Builder", false, true)}\
+          ${dropdownMenuItem(recordId, "tia-case-log", "fa-briefcase", "Case Log", false, true)}\
+        </ul>\
+      </li>\
+      <li class="tia-mobile-dropdown-menu">\
+        <span class="tia-button mobile-dropdown-button">\
+          <i class="fa fa-angle-down tia-dropdown" /> \
+          Update Case Details Menu\
+        </span>\
+        <ul class="tia-dropdown-menu-list" style="min-width: 152px; margin: .5em;">\
+          ${dropdownMenuItem(recordId, "edit-tia-case-details", "fa-edit", "Edit Case Details & Notes", false, true)}\
+          ${dropdownMenuItem(recordId, "assign-case-reviewers", "fa-users", "Assign Case Reviewers", false, true)}\
+          ${dropdownMenuItem(recordId, "change-tia-case-status", "fa-retweet", "Approve or Change Case Status", false, true)}\
+          ${dropdownMenuItem(recordId, "connected-cases", "fa-link", "Connect Cases", false, true)}\
+        </ul>\
+      </li>\
+      ${dropdownMenuItem(recordId, "edit-tia-fee-status-reviewer", "fa-dollar", "Fees", false, true)}\
+      ${dropdownMenuItem(recordId, "add-tia-communication", "fa-plus-circle", "Communication", false, true)}\
     </ul>\
   </div>`).appendTo("#view_744")
 })

--- a/code/transportation-development-services/tds.js
+++ b/code/transportation-development-services/tds.js
@@ -567,7 +567,7 @@ $(document).on("knack-view-render.view_321", function (event, page) {
 /**** TIA Menu Buttons Navigation ****/
 /*************************************/
 
-function dropdownMenuItem(recordId, route, iconName, linkName, newTab = false, mobile=false) {
+function dropdownMenuItem(recordId, route, iconName, linkName, mobile = false, newTab = false) {
   const buttonClass = mobile ? "tia-button" : "kn-button";
   if (newTab) {
     return (
@@ -644,11 +644,11 @@ $(document).on('knack-view-render.view_744', function(event, view, record) {
           Case Management Menu\
         </span>\
         <ul class="tia-dropdown-menu-list" style="min-width: 152px; margin: .5em;">\
-          ${dropdownMenuItem(recordId, "tia-case-details", "fa-list-alt", "Case Details", false, true)}\
-          ${dropdownMenuItem(recordId, "tia-case-management", "fa-archive", "Scope & Submissions", false, true)}\
-          ${dropdownMenuItem(recordId, "tia-mitigation-details", "fa-file-text-o", "Mitigations", false, true)}\
-          ${dropdownMenuItem(recordId, "memo-builder", "fa-medium", "Memo Builder", false, true)}\
-          ${dropdownMenuItem(recordId, "tia-case-log", "fa-briefcase", "Case Log", false, true)}\
+          ${dropdownMenuItem(recordId, "tia-case-details", "fa-list-alt", "Case Details", true)}\
+          ${dropdownMenuItem(recordId, "tia-case-management", "fa-archive", "Scope & Submissions", true)}\
+          ${dropdownMenuItem(recordId, "tia-mitigation-details", "fa-file-text-o", "Mitigations", true)}\
+          ${dropdownMenuItem(recordId, "memo-builder", "fa-medium", "Memo Builder", true)}\
+          ${dropdownMenuItem(recordId, "tia-case-log", "fa-briefcase", "Case Log", true)}\
         </ul>\
       </li>\
       <li class="tia-mobile-dropdown-menu">\
@@ -657,14 +657,14 @@ $(document).on('knack-view-render.view_744', function(event, view, record) {
           Update Case Details Menu\
         </span>\
         <ul class="tia-dropdown-menu-list" style="min-width: 152px; margin: .5em;">\
-          ${dropdownMenuItem(recordId, "edit-tia-case-details", "fa-edit", "Edit Case Details & Notes", false, true)}\
-          ${dropdownMenuItem(recordId, "assign-case-reviewers", "fa-users", "Assign Case Reviewers", false, true)}\
-          ${dropdownMenuItem(recordId, "change-tia-case-status", "fa-retweet", "Approve or Change Case Status", false, true)}\
-          ${dropdownMenuItem(recordId, "connected-cases", "fa-link", "Connect Cases", false, true)}\
+          ${dropdownMenuItem(recordId, "edit-tia-case-details", "fa-edit", "Edit Case Details & Notes", true)}\
+          ${dropdownMenuItem(recordId, "assign-case-reviewers", "fa-users", "Assign Case Reviewers", true)}\
+          ${dropdownMenuItem(recordId, "change-tia-case-status", "fa-retweet", "Approve or Change Case Status", true)}\
+          ${dropdownMenuItem(recordId, "connected-cases", "fa-link", "Connect Cases", true)}\
         </ul>\
       </li>\
-      ${dropdownMenuItem(recordId, "edit-tia-fee-status-reviewer", "fa-dollar", "Fees", false, true)}\
-      ${dropdownMenuItem(recordId, "add-tia-communication", "fa-plus-circle", "Communication", false, true)}\
+      ${dropdownMenuItem(recordId, "edit-tia-fee-status-reviewer", "fa-dollar", "Fees", true)}\
+      ${dropdownMenuItem(recordId, "add-tia-communication", "fa-plus-circle", "Communication", true)}\
     </ul>\
   </div>`).appendTo("#view_744")
 })
@@ -726,7 +726,7 @@ $(document).on('knack-view-render.view_886', function(event, view, record) {
         </ul>\
       </li>\
       ${dropdownMenuItem(recordId, "edit-mitigation-fee-status", "fa-dollar", "Mitigation Fees")}\
-      ${dropdownMenuItem(recordId, "feature-map", "fa-road", "Segment & Intersection Map", true)}\
+      ${dropdownMenuItem(recordId, "feature-map", "fa-road", "Segment & Intersection Map", false, true)}\
       ${dropdownMenuItem(recordId, "tia-mitigation-reporting", "fa-bar-chart", "Mitigation Reporting")}\
       ${dropdownMenuItem(recordId, "search-tia-mitigations", "fa-search", "Search Mitigations")}\
     </ul>\


### PR DESCRIPTION
![Screen Shot 2021-07-12 at 5 07 03 PM](https://user-images.githubusercontent.com/12474808/125489159-b9733616-90e5-443e-ad29-5ea9569b7941.png)

I tried to leverage the existing custom menu, and conditionally style it based on screen size, but knack has a lot of complex style rules under the hood that I kept running into. So unfortunately we have to add another chunk of code to include a mobile menu. 

Something I'd like to point out --
I updated the function that creates the buttons in the dropdown to toggle between knack's button `kn-button` (that displays block and in-line) and `tia-button` (our more controllable mobile button). I went back and forth with variable position, we can switch the order of the last two variables so you dont have to include `false` for `newTab` in every single invocation of the mobile menu. What will be used more often, mobile menus or newTabs?

