### PR TITLE
Update signs-markings.js

### DIFF
--- a/code/signs-markings/signs-markings.js
+++ b/code/signs-markings/signs-markings.js
@@ -246,6 +246,11 @@ $(document).on("knack-view-render.view_1880", function(event, page) {
   setRequester("field_2186", "#view_1880-field_2162", "object_151");
 });
 
+$(document).on("knack-view-render.view_3523", function(event, page) {
+  // Auto-populate requester divison field in MARKINGS New Work Order form -SBO
+  setRequester("field_2186", "#view_3523-field_2162", "object_151");
+});
+
 $(document).on("knack-view-render.view_2633", function(event, page) {
   // Auto-populate requester divison field in SIGNS New Work Order form
   setRequester("field_2186", "#view_2633-field_3216", "object_151");


### PR DESCRIPTION
Added SBO new work order markings view, so that JS could auto-populate the "Requester" field based on logged in user's division.