### PR TITLE
Fix missing add location button

### DIFF
--- a/code/signs-markings/signs-markings.js
+++ b/code/signs-markings/signs-markings.js
@@ -322,7 +322,7 @@ $(document).on("knack-scene-render.scene_1028", function(event, scene) {
   var $form = $("#view_2607");
   $form.attr("id", "lat-lon-form");
   $form.detach();
-  $("#view_2572").prepend($form);
+  $form.insertBefore("#view_2572")
   // Hide Latitude/Longitude fields and labels overlaying map
   $("#kn-input-field_3300 > div").hide();
 });


### PR DESCRIPTION
https://github.com/cityofaustin/atd-data-tech/issues/3777

The view with the button (2607) was being added to the Time view (2572) after the page rendered. But when a user added or removed a Technician, that view would reload and the button wasn't added. 

Instead now the button view (2607) will be inserted before the Time View (2572) and will be not affected by that table reloading. 