### PR TITLE
Autopopulate original work order ID in the follow-up process

### DIFF
--- a/code/data-tracker/data-tracker.js
+++ b/code/data-tracker/data-tracker.js
@@ -930,23 +930,63 @@ $(document).on("knack-view-render.view_1261", function (event, page) {
 // https://github.com/cityofaustin/atd-data-tech/issues/9052 //
 ///////////////////////////////////////////////////////////////
 
-$(document).on('knack-scene-render.scene_644', function(event, scene) {
-  // This is the record id that needs to be added to the autoselect
-  console.log("record id", scene.scene_id)
-  var originalWorkOrderId = scene.scene_id;
-  console.log(scene.scene_id === "61f853074373c6177acb4549")
+// We need to use a page render so we can take a value from one view
+// and use it to populate another. So, we wait for all views to load
+var waitForEls = function (selectorsArray, callback) {
+  var haveAllElementsLoadedArray = selectorsArray.map(function ($selector) {
+    return $selector.length > 0;
+  });
+  console.log(haveAllElementsLoadedArray);
+  if (!haveAllElementsLoadedArray.includes(false)) {
+    callback();
+  } else {
+    setTimeout(function () {
+      waitForEls(selectorsArray, callback);
+    }, 100);
+  }
+};
 
-  // Get the original work order ID
-  var $originalWorkOrderIdElement = $("div.field_1209 > div.kn-detail-body:last-child")
-  var originalWorkOrderIdText = $originalWorkOrderIdElement.text();
+$(document).on("knack-scene-render.scene_644", function (event, scene) {
+  var $placeholderText = $("div#view_1718_field_2075_chzn > a > span");
+  var $originalWorkOrderIdElement = $(
+    "div.field_1209 > div.kn-detail-body:last-child"
+  );
 
-  // Append
-  var selectedOptionElement = '<option value="' + originalWorkOrderId + '" selected>' + originalWorkOrderIdText + '</option>';
-  console.log(selectedOptionElement)
-  $("#view_1718-field_2075").append(selectedOptionElement)
+  // waitForEls([$placeholderText, $originalWorkOrderIdElement], function(){
+  //   var originalWorkOrderId = scene.scene_id;
+  //   console.log("record id", originalWorkOrderId)
+  //  var $placeholderTextDupe = $("div#view_1718_field_2075_chzn > a > span")
+  // var $originalWorkOrderIdElementDupe = $("div.field_1209 > div.kn-detail-body:last-child")
+  // console.log($placeholderText, $originalWorkOrderIdElement)
+  // // This is the record id that needs to be added to the autoselect
+  // // console.log("record id", scene.scene_id)
 
-  // Clear results and add the selected value
-  var $resultsUnorderedList = $("ul.chzn-results")
+  // // console.log(scene.scene_id === "61f853074373c6177acb4549")
+
+  // // Get the original work order ID
+  // // var $originalWorkOrderIdElement = $("div.field_1209 > div.kn-detail-body:last-child")
+  // var originalWorkOrderIdText = $originalWorkOrderIdElementDupe.text();
+
+  // // Append
+  // var selectedOptionElement = '<option value="' + originalWorkOrderId + '" selected>' + originalWorkOrderIdText + '</option>';
+  // console.log(selectedOptionElement)
+  // $("#view_1718-field_2075").append(selectedOptionElement)
+
+  // // Clear results and add the selected value
+  // var $searchInput = $("div.chzn-search > input")
+  // // Remove the placeholder item
+  // $searchInput.attr("placeholder", originalWorkOrderIdText)
+
+  // // var $placeholderText = $("div#view_1718_field_2075_chzn > a > span")
+  // $placeholderTextDupe.text(originalWorkOrderIdText);
+  // console.log($placeholderText.text());
+
+  // });
+
+  // var $placeholderText = $("div#view_1718_field_2075_chzn > a > span")
+  // $placeholderText.text(originalWorkOrderIdText)
+  // $placeholderText.text(originalWorkOrderIdText);
+  // console.log(originalWorkOrderIdText, $placeholderText);
 
   // console.log($("#view_1718-field_2075").val());
   // $("#view_1718-field_2075").val(originalWorkOrderId);
@@ -956,7 +996,7 @@ $(document).on('knack-scene-render.scene_644', function(event, scene) {
 
   // Do something after the scene renders
   // console.log('listener for scene: ' + scene.key);
-  
+
   // <option value="6227c624c26314001f57d1a1" selected>WRK22-138655</option>
 
   // Update the value of the original work order ID
@@ -966,7 +1006,36 @@ $(document).on('knack-scene-render.scene_644', function(event, scene) {
   // $originalWorkOrderIdInput.trigger("chosen:updated");
 });
 
-$(document).on('knack-view-render.view_1718', function(event, view, data) {
+$(document).on("knack-view-render.view_1718", function (event, view, data) {
   // Do something after the view renders
-  // console.log(data)
+  // console.log(data);
+  var $placeholderText = $("div#view_1718_field_2075_chzn > a > span");
+
+  // The DB id of the work order ID
+  var originalWorkOrderId = data.id;
+  // The human readable value of the work order ID
+  var originalWorkOrderIdText = data.field_1209;
+  console.log(originalWorkOrderId, originalWorkOrderIdText);
+  console.log($placeholderText);
+
+  // Build an option to append
+  var selectedOptionElement =
+    '<option value="' +
+    originalWorkOrderId +
+    '" selected>' +
+    originalWorkOrderIdText +
+    "</option>";
+  $("#view_1718-field_2075").append(selectedOptionElement);
+
+  // Clear results and add the selected value
+  var $searchInput = $("div.chzn-search > input");
+  // Remove the placeholder item
+  $searchInput.attr("placeholder", originalWorkOrderIdText);
+  $placeholderText.parent().change(function () {
+    console.log("changed");
+  });
+  $placeholderText.text(originalWorkOrderIdText);
+
+  $("#view_1718-field_2075").val(originalWorkOrderId);
+  $("#view_1718-field_2075").trigger("liszt:updated");
 });

--- a/code/data-tracker/data-tracker.js
+++ b/code/data-tracker/data-tracker.js
@@ -925,3 +925,48 @@ $(document).on("knack-view-render.view_1261", function (event, page) {
     "<span class='icon is-small'><i class='fa fa-list'></i></span><span>Cabinet details</span>"
   );
 });
+
+///////////////////////////////////////////////////////////////
+// https://github.com/cityofaustin/atd-data-tech/issues/9052 //
+///////////////////////////////////////////////////////////////
+
+$(document).on('knack-scene-render.scene_644', function(event, scene) {
+  // This is the record id that needs to be added to the autoselect
+  console.log("record id", scene.scene_id)
+  var originalWorkOrderId = scene.scene_id;
+  console.log(scene.scene_id === "61f853074373c6177acb4549")
+
+  // Get the original work order ID
+  var $originalWorkOrderIdElement = $("div.field_1209 > div.kn-detail-body:last-child")
+  var originalWorkOrderIdText = $originalWorkOrderIdElement.text();
+
+  // Append
+  var selectedOptionElement = '<option value="' + originalWorkOrderId + '" selected>' + originalWorkOrderIdText + '</option>';
+  console.log(selectedOptionElement)
+  $("#view_1718-field_2075").append(selectedOptionElement)
+
+  // Clear results and add the selected value
+  var $resultsUnorderedList = $("ul.chzn-results")
+
+  // console.log($("#view_1718-field_2075").val());
+  // $("#view_1718-field_2075").val(originalWorkOrderId);
+  // $("#view_1718-field_2075").trigger("liszt:updated");
+  // var updatedValue = $("#view_1718-field_2075").val();
+  // console.log(updatedValue)
+
+  // Do something after the scene renders
+  // console.log('listener for scene: ' + scene.key);
+  
+  // <option value="6227c624c26314001f57d1a1" selected>WRK22-138655</option>
+
+  // Update the value of the original work order ID
+  // var $originalWorkOrderIdInput = $("select#view_1718-field_2075");
+  // console.log($originalWorkOrderIdInput);
+  // $originalWorkOrderIdInput.chosen().val(originalWorkOrderId);
+  // $originalWorkOrderIdInput.trigger("chosen:updated");
+});
+
+$(document).on('knack-view-render.view_1718', function(event, view, data) {
+  // Do something after the view renders
+  // console.log(data)
+});

--- a/code/data-tracker/data-tracker.js
+++ b/code/data-tracker/data-tracker.js
@@ -927,6 +927,7 @@ $(document).on("knack-view-render.view_1261", function (event, page) {
 });
 
 ///////////////////////////////////////////////////////////////
+/// Autopopulate work order ID in the follow-up order form ////
 // https://github.com/cityofaustin/atd-data-tech/issues/9052 //
 ///////////////////////////////////////////////////////////////
 
@@ -938,13 +939,15 @@ $(document).on("knack-view-render.view_1718", function (event, view, data) {
   var originalWorkOrderIdText = data.field_1209;
   var originalWorkOrderId = data.id;
 
-  $("select#view_1718-field_2075").on("change", function () {
-    var $placeholderOption = $(this).find("option");
-    $placeholderOption.val(originalWorkOrderId);
-    $placeholderOption.text(originalWorkOrderIdText);
+  // Chosen.js updates this select after the view loads so we need to watch for that change
+  // This event blows away any DOM updates made before it
+  $workOrderIdSelect.on("change", function () {
+    // Disable this listener so we don't get an endless loop when we fire off one last change
     $(this).off();
+    // Update this select with the original work order ID as its value
     $(this).val(originalWorkOrderId).change();
 
+    // Update the span that normally prompts the type to search with the human-readable ID
     var $placeholderTextSpan = $("div#view_1718_field_2075_chzn > a > span");
     $placeholderTextSpan.text(originalWorkOrderIdText);
   });

--- a/code/data-tracker/data-tracker.js
+++ b/code/data-tracker/data-tracker.js
@@ -930,112 +930,22 @@ $(document).on("knack-view-render.view_1261", function (event, page) {
 // https://github.com/cityofaustin/atd-data-tech/issues/9052 //
 ///////////////////////////////////////////////////////////////
 
-// We need to use a page render so we can take a value from one view
-// and use it to populate another. So, we wait for all views to load
-var waitForEls = function (selectorsArray, callback) {
-  var haveAllElementsLoadedArray = selectorsArray.map(function ($selector) {
-    return $selector.length > 0;
-  });
-  console.log(haveAllElementsLoadedArray);
-  if (!haveAllElementsLoadedArray.includes(false)) {
-    callback();
-  } else {
-    setTimeout(function () {
-      waitForEls(selectorsArray, callback);
-    }, 100);
-  }
-};
-
-$(document).on("knack-scene-render.scene_644", function (event, scene) {
-  var $placeholderText = $("div#view_1718_field_2075_chzn > a > span");
-  var $originalWorkOrderIdElement = $(
-    "div.field_1209 > div.kn-detail-body:last-child"
-  );
-
-  // waitForEls([$placeholderText, $originalWorkOrderIdElement], function(){
-  //   var originalWorkOrderId = scene.scene_id;
-  //   console.log("record id", originalWorkOrderId)
-  //  var $placeholderTextDupe = $("div#view_1718_field_2075_chzn > a > span")
-  // var $originalWorkOrderIdElementDupe = $("div.field_1209 > div.kn-detail-body:last-child")
-  // console.log($placeholderText, $originalWorkOrderIdElement)
-  // // This is the record id that needs to be added to the autoselect
-  // // console.log("record id", scene.scene_id)
-
-  // // console.log(scene.scene_id === "61f853074373c6177acb4549")
-
-  // // Get the original work order ID
-  // // var $originalWorkOrderIdElement = $("div.field_1209 > div.kn-detail-body:last-child")
-  // var originalWorkOrderIdText = $originalWorkOrderIdElementDupe.text();
-
-  // // Append
-  // var selectedOptionElement = '<option value="' + originalWorkOrderId + '" selected>' + originalWorkOrderIdText + '</option>';
-  // console.log(selectedOptionElement)
-  // $("#view_1718-field_2075").append(selectedOptionElement)
-
-  // // Clear results and add the selected value
-  // var $searchInput = $("div.chzn-search > input")
-  // // Remove the placeholder item
-  // $searchInput.attr("placeholder", originalWorkOrderIdText)
-
-  // // var $placeholderText = $("div#view_1718_field_2075_chzn > a > span")
-  // $placeholderTextDupe.text(originalWorkOrderIdText);
-  // console.log($placeholderText.text());
-
-  // });
-
-  // var $placeholderText = $("div#view_1718_field_2075_chzn > a > span")
-  // $placeholderText.text(originalWorkOrderIdText)
-  // $placeholderText.text(originalWorkOrderIdText);
-  // console.log(originalWorkOrderIdText, $placeholderText);
-
-  // console.log($("#view_1718-field_2075").val());
-  // $("#view_1718-field_2075").val(originalWorkOrderId);
-  // $("#view_1718-field_2075").trigger("liszt:updated");
-  // var updatedValue = $("#view_1718-field_2075").val();
-  // console.log(updatedValue)
-
-  // Do something after the scene renders
-  // console.log('listener for scene: ' + scene.key);
-
-  // <option value="6227c624c26314001f57d1a1" selected>WRK22-138655</option>
-
-  // Update the value of the original work order ID
-  // var $originalWorkOrderIdInput = $("select#view_1718-field_2075");
-  // console.log($originalWorkOrderIdInput);
-  // $originalWorkOrderIdInput.chosen().val(originalWorkOrderId);
-  // $originalWorkOrderIdInput.trigger("chosen:updated");
-});
-
 $(document).on("knack-view-render.view_1718", function (event, view, data) {
-  // Do something after the view renders
-  // console.log(data);
-  var $placeholderText = $("div#view_1718_field_2075_chzn > a > span");
+  // Select and clone the original work order ID select field
+  var $workOrderIdSelect = $("select#view_1718-field_2075");
 
-  // The DB id of the work order ID
-  var originalWorkOrderId = data.id;
-  // The human readable value of the work order ID
+  // Update the field placeholder text so it looks like the original work order ID is chosen
   var originalWorkOrderIdText = data.field_1209;
-  console.log(originalWorkOrderId, originalWorkOrderIdText);
-  console.log($placeholderText);
+  var originalWorkOrderId = data.id;
 
-  // Build an option to append
-  var selectedOptionElement =
-    '<option value="' +
-    originalWorkOrderId +
-    '" selected>' +
-    originalWorkOrderIdText +
-    "</option>";
-  $("#view_1718-field_2075").append(selectedOptionElement);
+  $("select#view_1718-field_2075").on("change", function () {
+    var $placeholderOption = $(this).find("option");
+    $placeholderOption.val(originalWorkOrderId);
+    $placeholderOption.text(originalWorkOrderIdText);
+    $(this).off();
+    $(this).val(originalWorkOrderId).change();
 
-  // Clear results and add the selected value
-  var $searchInput = $("div.chzn-search > input");
-  // Remove the placeholder item
-  $searchInput.attr("placeholder", originalWorkOrderIdText);
-  $placeholderText.parent().change(function () {
-    console.log("changed");
+    var $placeholderTextSpan = $("div#view_1718_field_2075_chzn > a > span");
+    $placeholderTextSpan.text(originalWorkOrderIdText);
   });
-  $placeholderText.text(originalWorkOrderIdText);
-
-  $("#view_1718-field_2075").val(originalWorkOrderId);
-  $("#view_1718-field_2075").trigger("liszt:updated");
 });

--- a/code/data-tracker/data-tracker.js
+++ b/code/data-tracker/data-tracker.js
@@ -952,3 +952,7 @@ $(document).on("knack-view-render.view_1718", function (event, view, data) {
     $placeholderTextSpan.text(originalWorkOrderIdText);
   });
 });
+
+//////////////////////////////////////////////////////////////////
+/// End Autopopulate work order ID in the follow-up order form ///
+//////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/9052

## Testing
**URL to test:** <!-- https://moped-test.austinmobility.io/moped/ or Netlify -->
https://atd.knack.com/test--austin-transportation-data-tracker--31-jan-2022#work-orders/work-order-details/61f852ef4373c6177acb3dd8/

**Steps to test:**
1. Go to a work order in `TEST | Austin Transportation Data Tracker | 31 JAN 2022` like the one above
2. Make sure that you are logged in as a user that has one of the following roles
   - Program Editors
   - Lead Tech | AMDs
   - Tech Supervisor | AMDs
4. In the Work Order Details view, click the "Follow-Up Work Order" button
5. When that view loads, you should see the original work order ID that is already on the page populated in the select field of the form
6. Fill out any other details and save the changes
7. A new follow-up order will be created with the correct parent work order