### PR TITLE
Disabled breadcrumbs to hidden parent SSPR page

### DIFF
--- a/code/hr/hr.js
+++ b/code/hr/hr.js
@@ -92,3 +92,25 @@ $(document).on("knack-view-render.view_32", function(event, page) {
   $('#view_32-field_105').val(attrs.id);
   $('#view_32-field_105').trigger("liszt:updated");
 });
+
+/***************************************************************/
+/*** Disable the ability to Click/Touch outside a Modal Page ***/
+/***************************************************************/
+$(document).on('knack-scene-render.any', function(event, scene) {
+    $('.kn-modal-bg').off('click');
+});
+
+/*** Disable Breadcrumb Navigation Links ***/
+/*******************************************/
+function disableBreadCrumbsNonAdmin() {
+  if (!Knack.user.session) {
+    $(".kn-crumbtrail a").each(function () {
+      $(this).replaceWith($(this).text());
+    });
+  }
+}
+
+//Page to disable crumbtrail
+$(document).on("knack-scene-render.scene_165", function () {
+  disableBreadCrumbsNonAdmin();
+});

--- a/code/hr/hr.js
+++ b/code/hr/hr.js
@@ -110,7 +110,7 @@ function disableBreadCrumbsNonAdmin() {
   }
 }
 
-//Page to disable crumbtrail
+//Page to disable crumbtrail in SSPR Details
 $(document).on("knack-scene-render.scene_165", function () {
   disableBreadCrumbsNonAdmin();
 });


### PR DESCRIPTION
I disabled a page that I didn't want users to click on accidentally, it's a hidden parent page. I'm using a menu to go back to the page I want them to redirect to.