### PR TITLE
VZA: Remove date filter from officer assignments request

### DIFF
--- a/code/vza/vza.js
+++ b/code/vza/vza.js
@@ -854,7 +854,7 @@ $(document).on("knack-view-render.view_466", function (event, view, data) {
   $("#" + appSpecifics.availableAssignmentsView + "> div.view-header")
     .after(recordsTable)
     .ready(function () {
-      // Records returned from this API view are filtered by date (assignment occurs today or in the next 28 days)
+      // The API view filters records by date (assignment occurs today or in the next 28 days) before returning records
       requestRecords([], view.key, tableConfig);
     });
 });

--- a/code/vza/vza.js
+++ b/code/vza/vza.js
@@ -57,21 +57,6 @@ var userId = Knack.getUserAttributes().id;
 
 // Filter for records for assignments time windows
 var filters = {
-  nextFourWeeks: {
-    match: "or",
-    rules: [
-      {
-        field: fields.dateField,
-        operator: "is today",
-      },
-      {
-        field: fields.dateField,
-        operator: "is during the next",
-        range: 28,
-        type: "days",
-      },
-    ],
-  },
   today: [
     {
       field: fields.dateField,
@@ -869,7 +854,8 @@ $(document).on("knack-view-render.view_466", function (event, view, data) {
   $("#" + appSpecifics.availableAssignmentsView + "> div.view-header")
     .after(recordsTable)
     .ready(function () {
-      requestRecords(filters.nextFourWeeks, view.key, tableConfig);
+      // Records returned from this API view are filtered by date (assignment occurs today or in the next 28 days)
+      requestRecords([], view.key, tableConfig);
     });
 });
 


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/10764

This PR removes date filtering from the request that populates current officer assignments in the **Sign Up** view that had stopped working. The request was returning **all** assignments instead - including those far in the past. To avoid this breaking in the future, I updated the Knack API view that feeds this request to filter on the date instead (filtered to today or in the next four weeks).

### Before
<img width="1232" alt="Screenshot 2022-11-14 at 4 49 37 PM" src="https://user-images.githubusercontent.com/37249039/201784402-598c5f44-4ebf-4f3f-a2e9-e541b40e8e7e.png">

### After
<img width="1232" alt="Screenshot 2022-11-14 at 4 48 22 PM" src="https://user-images.githubusercontent.com/37249039/201784490-fd760e50-ae53-4649-9bb5-c9f07e18357a.png">

## Testing
1. Go to https://atd.knack.com/test-vision-zero-in-action-3-feb-2021#sign-up
2. Sign in with the login stored in 1Pass as `Vision Zero | Production - Officer` (in the Knack shared vault)
3. You should see one officer assignment that I manually updated the assignment date to be today, Nov. 14