### PR TITLE
Update smart-mobility.css for new LS EOI

### DIFF
--- a/code/smart-mobility/smart-mobility.css
+++ b/code/smart-mobility/smart-mobility.css
@@ -67,3 +67,23 @@ a.small-button {
   display: none;
 }
 
+/*Living Streets EOI NEW - Timeframe*/
+#kn-scene_276 .kn-back-link {
+  display: none;
+}
+/*Healthy Streets EOI NEW- Finalize and Submit page*/
+#kn-scene_277 .kn-back-link {
+  display: none;
+}
+/*Healthy Streets EOI NEW- Confirmation 9age*/
+#kn-scene_280 .kn-back-link {
+  display: none;
+}
+/*Play Streets EOI NEW- Finalize and Submit page*/
+#kn-scene_281 .kn-back-link {
+  display: none;
+}
+/*Play Streets EOI NEW- Confirmation page*/
+#kn-scene_284 .kn-back-link {
+  display: none;
+}


### PR DESCRIPTION
Disabling backlinks in the new Living Streets EOI cascade form
- Added this prior to go-live since it's a new form not in use (and thus don't have to wait until go-live window to set it up)
- After successful go-live, the previous EOI form will be deprecated and those lines can be cleaned up