### PR TITLE
Add Print buttons for Reviewer page in Mobility Services Portal (MSP)

### DIFF
--- a/code/mobility-services/mobility-services.css
+++ b/code/mobility-services/mobility-services.css
@@ -272,10 +272,10 @@ a.small-button {
 /********************************************/
 /****** Print Application Header ************/
 /********************************************/
-#kn-scene_65, #kn-scene_83 {
+#kn-scene_65, #kn-scene_83, #kn-scene_100, #kn-scene_101 {
   counter-reset: page;
 }
-#kn-scene_65 .view-group, #kn-scene_83 .view-group {
+#kn-scene_65 .view-group, #kn-scene_83 .view-group, #kn-scene_100 .view-group, #kn-scene_101 .view-group  {
   display: block; /* avoids text overlapping */
 }
 

--- a/code/mobility-services/mobility-services.js
+++ b/code/mobility-services/mobility-services.js
@@ -132,13 +132,21 @@ function printMenuButton(view_id) {
 }
 
 /* Print 3 pages menu view button */
-$(document).on('knack-view-render.view_227', function(event, view, data) {
+$(document).on('knack-view-render.view_227', function(event, view, data) { // Customer Print
   printMenuButton('view_227');
 });
 
+$(document).on('knack-view-render.view_315', function(event, view, data) { // Reviewer Print
+  printMenuButton('view_315');
+});
+
 /* Print 4 pages menu view button */
-$(document).on('knack-view-render.view_228', function(event, view, data) {
+$(document).on('knack-view-render.view_228', function(event, view, data) { // Customer Print
   printMenuButton('view_228');
+});
+
+$(document).on('knack-view-render.view_304', function(event, view, data) { // Reviewer Print
+  printMenuButton('view_304'); 
 });
 
 /***************************************


### PR DESCRIPTION
This is some JS and CSS changes added for the reviewer page of the Chauffeur Permit application in the Mobility Services Portal
Related Issue: https://github.com/cityofaustin/atd-data-tech/issues/18567

# JS
Reviewer page will have a print menu button in the "Print Application" pages
   - `view_227` is for a 3 page version
   - `view_228` is for a 4 page version (if applicant has a lot of text)

# CSS
The CSS adds a `display block` to both the 3 page and 4 page view for pdf print page "Print Application" to avoid the overlapping text view in the following scenes:
 - `scene_100`
 - `scene_101`

# Related Gitbook docs
Print menu button: https://atd-dts.gitbook.io/atd-knack-operations/knack-code/code-knack-print-page/print-using-menu-button
Avoid overlapping views: https://atd-dts.gitbook.io/atd-knack-operations/knack-code/code-knack-print-page/print-without-overlapping-views