### PR TITLE
MSP - Changed input validation from 11 to last 4 digits only

### DIFF
--- a/code/mobility-services/mobility-services.js
+++ b/code/mobility-services/mobility-services.js
@@ -35,7 +35,7 @@ $(document).on('knack-view-render.view_57', function(event, page) {
 });
 
 /***************************************/
-/**** Input Mask number for SSN ********/
+/**** Input validation for SSN ********/
 /***************************************/
 $(document).on('knack-view-render.any', function (event, view, data) {
   $('input#field_33').keyup(function(event) { // validates typing
@@ -48,18 +48,8 @@ $(document).on('knack-view-render.any', function (event, view, data) {
     } else if (isNaN(Number(event.key))) { // if not number
       this.value = this.value.replace(/[^0-9\s-]+/g, '');
     }
-    if (this.value.charAt(3) != " "){
-      this.value = this.value.replace(/^(.{3})(.*)$/, "$1 $2"); // replace if no space at 4th position
-    }
-    if (this.value.charAt(6) != " "){ // replace if no spaces at 7th position
-      this.value = this.value.replace(/^(.{6})(.*)$/, "$1 $2");
-    }
-
   });
-  /* Validation */
-  $("input#field_33").attr('maxlength', 11);
-  $("input#field_33").attr('placeholder',"___ __ ____");
-
+  $("input#field_33").attr('maxlength', 4); // only max is 4 length
 });
 
 /********************************************************/


### PR DESCRIPTION
After talking with Mobility Services staff, we are changing the input to last 4 digits instead of full.
Related Issue: https://github.com/cityofaustin/atd-data-tech/issues/18636

Form: https://atd.knack.com/mobility-services#application-chauffeur/

- Change input mask comment to input validation in line 38 comment for accuracy
- Removed spacing auto input line 51-57
- Change to `max length` of 4 instead of 11
- Removed `placeholder` line 61

