### PR TITLE
Operating Authority Added Dropdown Menu View, Step Indicator, Print Notary

### DIFF
--- a/code/mobility-services/mobility-services.css
+++ b/code/mobility-services/mobility-services.css
@@ -437,7 +437,7 @@ a.small-button {
 }
 
 .image-seal {
-  content: url("https://www.austintexas.gov/sites/default/files/images/Transportation/Home_Page_Gallery/2023%20Austin%20Transportation%20Public%20Works%20Branding%20Guide%2004.28.23_Color%20stack.png");
+  content: url("https://files.gitbook.com/v0/b/gitbook-x-prod.appspot.com/o/spaces%2FCqNGfEc0WO4ar1y6yBB3%2Fuploads%2FdxBFascjuN72Cl1NwFMQ%2Fimage.png?alt=media&token=caaa96e0-8684-4747-b936-f5501a1259f6");
   width: 152px;
   height: 113.324px;
   display: inline-block;

--- a/code/mobility-services/mobility-services.css
+++ b/code/mobility-services/mobility-services.css
@@ -1,42 +1,44 @@
 /***************************/
 /**** Step Indicator *******/
 /***************************/
-.stepindicator{
-  width: 100%;
+/* General Step Indicator */
+/* Chauffeur Permit Form  */
+.stepindicator {
+  width: 120%;
   z-index: 1;
-  display: flex;
-  position:static;
+  display: inline-flex;
+  position: static;
 }
-.label-stepindicator{
-  display:inline-block;
+.label-stepindicator {
+  display: inline-block;
   width: 1.5em;
-  height:1.5em;
-  background: #005EA2;
+  height: 1.5em;
+  background: #005ea2;
   border-radius: 50%;
   text-align: center;
   font-weight: bold;
   color: white;
   line-height: 1.5em;
-  font-size:1.5em;
+  font-size: 1.5em;
 }
 
-.active-label-stepindicator{
+.active-label-stepindicator {
   font-weight: bold;
-  font-size:1.5em;
-  margin-left:20px;
+  font-size: 1.5em;
+  margin-left: 20px;
 }
-.progressbar{
+.progressbar {
   counter-reset: step;
 }
 
 /* This is for the Circle number */
-.progressbar li:before{
-  content:counter(step);
+.progressbar li:before {
+  content: counter(step);
   counter-increment: step;
   width: 30px;
   height: 30px;
   border: 2px solid #bebebe;
-  display:block;
+  display: block;
   border-radius: 50%;
   line-height: 26px;
   background: white;
@@ -46,7 +48,7 @@
 }
 
 /* This is for the bars */
-.progressbar li{ /* Chauffeur Permit Form */
+.progressbar li {
   list-style-type: none;
   float: left;
   width: 25%;
@@ -55,22 +57,14 @@
   margin-left: -5px;
 }
 
-.progressbar #oa { /* Operating Authority Form */
-  list-style-type: none;
-  float: left;
-  width: 15%;
-  position: relative;
-  text-align: left;
-  margin-left: -1px;
-}
 .progressbar li + li {
   margin-top: unset;
 }
 
-.progressbar li:after{
-  content: '';
+.progressbar li:after {
+  content: "";
   position: absolute;
-  width:100%;
+  width: 100%;
   height: 8px;
   background: #979797;
   top: 10px;
@@ -79,38 +73,86 @@
 }
 
 /* Hides the first child bar */
-.progressbar li:first-child:after{
+.progressbar li:first-child:after {
   content: none;
 }
 
-.progressbar li.active + li:after{
-  background: #005EA2;
+.progressbar li.active + li:after {
+  background: #005ea2;
 }
 
-.progressbar li.active::before{
+.progressbar li.active::before {
   border: 2px solid white;
-  background: #005EA2;
+  background: #005ea2;
   color: white;
 }
-.progressbar li.active{
+.progressbar li.active {
   font-weight: bold;
-  color: #005EA2;
+  color: #005ea2;
 }
-.progressbar li.inactive{
+.progressbar li.inactive {
   font-weight: bold;
   color: #163f6e;
 }
-.progressbar li.inactive + li:after{
+.progressbar li.inactive + li:after {
   background: #163f6e;
 }
 
-.progressbar li.inactive::before{
+.progressbar li.inactive::before {
   border-color: white;
   background: #163f6e;
   color: white;
 }
 
+/***************************/
+/**** Step Indicator *******/
+/***************************/
+/* Operating Authority Form Only */
+.progressbar #oa {
+  list-style-type: none;
+  float: left;
+  width: 15%;
+  position: relative;
+  text-align: left;
+  margin-left: -1px;
+}
 
+/***************************/
+/**** Step Indicator *******/
+/***************************/
+/* For mobile screens step indicator */
+@media only screen and (max-width: 600px) {
+  .progressbar li:before {
+    margin-top: -33px;
+    line-height: 18px;
+    width: 20px;
+    height: 20px;
+    border-width: 1px;
+  }
+
+  .progressbar li#oa,
+  .progressbar li#oa.active,
+  .progressbar li#oa.inactive {
+    font-size: 9.5px;
+  }
+
+  .progressbar li.active::before {
+    border-width: 1px;
+  }
+
+  .progressbar li,
+  .progressbar li.active,
+  .progressbar li.inactive {
+    font-size: 11px;
+    padding-top: 15px;
+  }
+
+  .progressbar li:after {
+    border-left: 1px solid white;
+    height: 10px;
+    margin-top: -2em;
+  }
+}
 /***************************************/
 /*********** Trigger Buttons ***********/
 /***************************************/
@@ -170,7 +212,9 @@
   outline-color: transparent;
 }
 
-a.trigger-button-large {text-decoration: none;}
+a.trigger-button-large {
+  text-decoration: none;
+}
 
 /***************************************/
 /***************************************/
@@ -203,12 +247,14 @@ a.big-button-container {
 /****************************************/
 /************ Button Effects ************/
 /****************************************/
-//.disabled { cursor: not-allowed; }
+/* .disabled { cursor: not-allowed; } // disabled for visual bug in big trigger button */
 
 /***************************************/
 /********* FA Icon Positioning *********/
 /***************************************/
-.fa { vertical-align: baseline; }
+.fa {
+  vertical-align: baseline;
+}
 
 /***************************************/
 /************ Small Buttons ************/
@@ -237,101 +283,146 @@ a.big-button-container {
 a.small-button {
   text-decoration: none;
 }
+
 /****************************************/
 /*** Dropdown Menu Buttons Navigation ***/
 /****************************************/
 
 /* hide custom menu if on mobile */
-@media (max-width: 799px) {
-  #tia-menu-list {
+@media (max-width: 770px) {
+  #desktop-menu-list {
     display: none;
   }
 }
 
 /* hide knack menu buttons if on desktop */
-@media (min-width: 799px) {
-  #view_163 {
+@media (min-width: 770px) {
+  #mobile-menu-list {
     display: none;
   }
 }
 
 /*list, list item, and button stylings*/
-#oa-menu-list {
-  border-bottom: 0 !important
+#desktop-menu-list {
+  border-bottom: 0 !important;
 }
 
-#oa-menu-list li {
-  margin-right: .5em;
+#desktop-menu-list li {
+  margin-right: 0.5em;
   box-shadow: 0px 2px 4px 0px gray;
 }
 
-#oa-menu-list .kn-button a {
+#desktop-menu-list .kn-button a {
   color: #163f6e;
   font-size: 1.1em;
   border-bottom: 0;
-  padding-top:3px;
+  padding-top: 3px;
 }
 
-.oa-dropdown-menu-list .kn-button {
-  border-radius: 0;
+.desktop-dropdown-menu-list .kn-button {
+  border-radius: 1px;
 }
 
-.oa-dropdown-menu-list li {
+.desktop-dropdown-menu-list li {
   border: 0;
   margin-right: 0 !important;
-} 
+}
 
-.oa-dropdown-menu-list li:hover {
-  background-color: rgb(235,235,235);
+.desktop-dropdown-menu-list li:hover {
+  background-color: #ebebeb;
+}
+
+/*Mobile list, list item, and button stylings*/
+.mobile-details-dropdown-menu ul {
+  margin-left: 0.25em;
+}
+
+#mobile-menu-list {
+  list-style-type: none;
+  margin: 0;
+}
+
+#mobile-menu-list li {
+  margin-top: 5px;
+}
+
+#mobile-menu-list ul {
+  list-style-type: none;
+}
+
+#mobile-menu-list .kn-button a {
+  padding: 5px;
+  text-decoration: none;
+}
+
+.mobile-dropdown-menu span {
+  margin-top: 0.25em;
+  color: #163f6e;
+}
+
+.mobile-dropdown-menu-list {
+  margin-top: 1em;
+}
+
+.mobile-dropdown-menu-list.active {
+  display: inherit;
 }
 
 /******************************************************/
 /********* Style Horizontal radio buttons ************/
 /*****************************************************/
- #kn-input-field_46 
-  .kn-radio { display: flex; flex-direction: row; flex-wrap: nowrap; }
-  .control { margin-right: .5em;}
-
- #kn-input-field_47
-  .kn-radio { display: flex; flex-direction: row; flex-wrap: nowrap; }
-  .control { margin-right: .5em;}
-
- #kn-input-field_50
-  .kn-radio { display: flex; flex-direction: row; flex-wrap: nowrap; }
-  .control { margin-right: .5em;}
-
- #kn-input-field_51
-  .kn-radio { display: flex; flex-direction: row; flex-wrap: nowrap; }
-  .control { margin-right: .5em;}
-
- #kn-input-field_54
-  .kn-radio { display: flex; flex-direction: row; flex-wrap: nowrap; }
-  .control { margin-right: .5em;}
-
-#kn-input-field_75
-  .kn-radio { display: flex; flex-direction: row; flex-wrap: nowrap; }
-  .control { margin-right: .5em;}
+#kn-input-field_46 .kn-radio,
+#kn-input-field_47 .kn-radio,
+#kn-input-field_50 .kn-radio,
+#kn-input-field_51 .kn-radio,
+#kn-input-field_54 .kn-radio,
+#kn-input-field_75 .kn-radio {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+}
+.control {
+  margin-right: 0.5em;
+}
 
 /*Mobile Detail labels for printing*/
 
 /* Prints 3 pages */
-#view_212 .kn-detail-label { background-color: transparent; min-width: 60% !important;}
-#view_236 .kn-detail-label { background-color: transparent; min-width: 80% !important;}
-#view_214 .kn-detail-label { background-color: transparent; min-width: 80% !important;}
+#view_212 .kn-detail-label {
+  background-color: transparent;
+  min-width: 60% !important;
+}
+#view_236 .kn-detail-label,
+#view_214 .kn-detail-label {
+  background-color: transparent;
+  min-width: 80% !important;
+}
 
 /* Prints 4 pages */
-#view_105 .kn-detail-label { background-color: transparent; min-width: 60% !important;}
-#view_237 .kn-detail-label { background-color: transparent; min-width: 80% !important;}
-#view_184 .kn-detail-label { background-color: transparent; min-width: 80% !important;}
-#view_195 .kn-detail-label { background-color: transparent; min-width: 80% !important;}
+#view_105 .kn-detail-label {
+  background-color: transparent;
+  min-width: 60% !important;
+}
+#view_237 .kn-detail-label,
+#view_184 .kn-detail-label,
+#view_195 .kn-detail-label {
+  background-color: transparent;
+  min-width: 80% !important;
+}
 
 /********************************************/
 /****** Print Application Header ************/
 /********************************************/
-#kn-scene_65, #kn-scene_83, #kn-scene_100, #kn-scene_101 {
+#kn-scene_65,
+#kn-scene_83,
+#kn-scene_100,
+#kn-scene_101 {
   counter-reset: page;
 }
-#kn-scene_65 .view-group, #kn-scene_83 .view-group, #kn-scene_100 .view-group, #kn-scene_101 .view-group {
+#kn-scene_65 .view-group,
+#kn-scene_83 .view-group,
+#kn-scene_100 .view-group,
+#kn-scene_101 .view-group {
   display: block; /* avoids text overlapping */
 }
 
@@ -340,36 +431,38 @@ a.small-button {
   align-items: flex-start;
   flex-direction: row;
   justify-content: center;
-  font-family:'Trebuchet MS', 'Lucida Sans Unicode', 'Lucida Grande', 'Lucida Sans', Arial, sans-serif;
-  break-before:page;
+  font-family: "Trebuchet MS", "Lucida Sans Unicode", "Lucida Grande",
+    "Lucida Sans", Arial, sans-serif;
+  break-before: page;
 }
 
 .image-seal {
-  content:url("https://www.austintexas.gov/sites/default/files/images/Transportation/Home_Page_Gallery/2023%20Austin%20Transportation%20Public%20Works%20Branding%20Guide%2004.28.23_Color%20stack.png");
-  width: 152px; 
+  content: url("https://www.austintexas.gov/sites/default/files/images/Transportation/Home_Page_Gallery/2023%20Austin%20Transportation%20Public%20Works%20Branding%20Guide%2004.28.23_Color%20stack.png");
+  width: 152px;
   height: 113.324px;
-  display: inline-block; 
+  display: inline-block;
   vertical-align: top;
-  border-right: 3px solid #2B5EA0;
+  border-right: 3px solid #2b5ea0;
 }
 
 .text-header {
   justify-content: center;
-  font-family:'Trebuchet MS', 'Lucida Sans Unicode', 'Lucida Grande', 'Lucida Sans', Arial, sans-serif;
-  display: inline-block; 
-  vertical-align: top; 
+  font-family: "Trebuchet MS", "Lucida Sans Unicode", "Lucida Grande",
+    "Lucida Sans", Arial, sans-serif;
+  display: inline-block;
+  vertical-align: top;
   margin-left: 10px;
 }
 
 .header-title {
-  color: #2B5EA0;
-  font-weight:lighter;
-  font-size:1.5em;
+  color: #2b5ea0;
+  font-weight: lighter;
+  font-size: 1.5em;
 }
 
 /* Page Number Counter setup */
 .page-counter {
-  display:block;
+  display: block;
   text-align: right;
   margin-top: 10px;
 }
@@ -379,42 +472,18 @@ a.small-button {
   content: counter(page);
 }
 
-/* For mobile screens step indicator */ 
-@media only screen and (max-width: 600px) {
-  .progressbar li:before{
-    margin-top: -33px;
-    line-height: 18px;
-    width:20px;
-    height:20px;
-    border-width: 1px;
-  }
-  .progressbar li.active::before{
-    border-width: 1px;
-  }
-  
-  .progressbar li, .progressbar li.active, .progressbar li.inactive {
-    font-size: 11px;
-    padding-top: 15px;
-  }
-  
-  .progressbar li:after{
-    border-left: 1px solid white;
-    height: 10px;
-    margin-top: -2em;
-  }
-
-}
-
 /* Print Operating Authoriy Notary */
 /*640 and 639 is text content for notary. 614 is form*/
-#view_640, #view_639 { 
-    display:none;
+#view_640,
+#view_639 {
+  display: none;
 }
 @media print {
   #view_614 {
-    display:none;
+    display: none;
   }
-  #view_640, #view_639 {
-    display:contents;
+  #view_640,
+  #view_639 {
+    display: contents;
   }
 }

--- a/code/mobility-services/mobility-services.css
+++ b/code/mobility-services/mobility-services.css
@@ -46,13 +46,22 @@
 }
 
 /* This is for the bars */
-.progressbar li{
+.progressbar li{ /* Chauffeur Permit Form */
   list-style-type: none;
   float: left;
   width: 25%;
   position: relative;
   text-align: left;
   margin-left: -5px;
+}
+
+.progressbar #oa { /* Operating Authority Form */
+  list-style-type: none;
+  float: left;
+  width: 15%;
+  position: relative;
+  text-align: left;
+  margin-left: -1px;
 }
 .progressbar li + li {
   margin-top: unset;
@@ -194,7 +203,7 @@ a.big-button-container {
 /****************************************/
 /************ Button Effects ************/
 /****************************************/
-.disabled { cursor: not-allowed; }
+//.disabled { cursor: not-allowed; }
 
 /***************************************/
 /********* FA Icon Positioning *********/
@@ -227,6 +236,53 @@ a.big-button-container {
 
 a.small-button {
   text-decoration: none;
+}
+/****************************************/
+/*** Dropdown Menu Buttons Navigation ***/
+/****************************************/
+
+/* hide custom menu if on mobile */
+@media (max-width: 799px) {
+  #tia-menu-list {
+    display: none;
+  }
+}
+
+/* hide knack menu buttons if on desktop */
+@media (min-width: 799px) {
+  #view_163 {
+    display: none;
+  }
+}
+
+/*list, list item, and button stylings*/
+#oa-menu-list {
+  border-bottom: 0 !important
+}
+
+#oa-menu-list li {
+  margin-right: .5em;
+  box-shadow: 0px 2px 4px 0px gray;
+}
+
+#oa-menu-list .kn-button a {
+  color: #163f6e;
+  font-size: 1.1em;
+  border-bottom: 0;
+  padding-top:3px;
+}
+
+.oa-dropdown-menu-list .kn-button {
+  border-radius: 0;
+}
+
+.oa-dropdown-menu-list li {
+  border: 0;
+  margin-right: 0 !important;
+} 
+
+.oa-dropdown-menu-list li:hover {
+  background-color: rgb(235,235,235);
 }
 
 /******************************************************/
@@ -275,7 +331,7 @@ a.small-button {
 #kn-scene_65, #kn-scene_83, #kn-scene_100, #kn-scene_101 {
   counter-reset: page;
 }
-#kn-scene_65 .view-group, #kn-scene_83 .view-group, #kn-scene_100 .view-group, #kn-scene_101 .view-group  {
+#kn-scene_65 .view-group, #kn-scene_83 .view-group, #kn-scene_100 .view-group, #kn-scene_101 .view-group {
   display: block; /* avoids text overlapping */
 }
 
@@ -347,4 +403,18 @@ a.small-button {
     margin-top: -2em;
   }
 
+}
+
+/* Print Operating Authoriy Notary */
+/*640 and 639 is text content for notary. 614 is form*/
+#view_640, #view_639 { 
+    display:none;
+}
+@media print {
+  #view_614 {
+    display:none;
+  }
+  #view_640, #view_639 {
+    display:contents;
+  }
 }

--- a/code/mobility-services/mobility-services.js
+++ b/code/mobility-services/mobility-services.js
@@ -33,6 +33,10 @@ $(document).on('knack-view-render.view_57', function(event, page) {
   // create large CUSTOMER PORTAL button on the PORTAL page
     bigButton('available-services', 'view_57', "https://atd.knack.com/mobility-services#portal/", "arrow-right", "Mobility Services Portal");
 });
+$(document).on('knack-view-render.view_383', function(event, page) {
+  // create large START APPLICATION button on the Operating Authority page
+    bigButton('start-application', 'view_383', "https://atd.knack.com/mobility-services#application-operating-authority", "arrow-right", "Start Operating Authority Application");
+});
 
 /***************************************/
 /**** Input validation for SSN ********/
@@ -121,7 +125,7 @@ function printMenuButton(view_id) {
   });
 }
 
-/* Print 3 pages menu view button */
+/* Print 3 pages menu view button - Chauffeur Permit*/
 $(document).on('knack-view-render.view_227', function(event, view, data) { // Customer Print
   printMenuButton('view_227');
 });
@@ -130,13 +134,18 @@ $(document).on('knack-view-render.view_315', function(event, view, data) { // Re
   printMenuButton('view_315');
 });
 
-/* Print 4 pages menu view button */
+/* Print 4 pages menu view button - Chauffeur Permit*/
 $(document).on('knack-view-render.view_228', function(event, view, data) { // Customer Print
   printMenuButton('view_228');
 });
 
 $(document).on('knack-view-render.view_304', function(event, view, data) { // Reviewer Print
   printMenuButton('view_304'); 
+});
+
+/* Print Operating Authority Notary Page */
+$(document).on('knack-view-render.view_480', function(event, view, data) { // Company Print
+  printMenuButton('view_480'); 
 });
 
 /***************************************
@@ -190,3 +199,43 @@ $(document).on("knack-view-render.any", function (event, page) {
     customizeLoginButton(viewId);
   }
 });
+
+/****************************************/
+/*** Dropdown Menu Buttons Navigation ***/
+/****************************************/
+function dropdownMenuItem(recordId, route, linkName) {
+  return (
+    `<li class="kn-button">\
+      <a href="#application-operating-authority/business-information/${recordId}/${route}/${recordId}">\
+        <span>${linkName}</span>\
+      </a>\
+    </li>`)
+}
+
+// Dictonary of views needing dropdown menu in editable Operating Authority (OA) pages
+var viewNameOA = {687:"1 - Service Type",676:"2 - Business Information",689:"3 - Insurance", 
+691:"4 - Authorized Person", 693:"5 - Vehicle Information", 695:"6 - Review and Submit"};
+
+for (let key in viewNameOA) {
+  $(document).on('knack-view-render.view_' + key, function(event, view, record) {
+    var recordId = view.scene.scene_id;
+    var currentMenu = viewNameOA[key];
+
+    $(`<div class="details-dropdown-menu tabs">\
+      <ul id="oa-menu-list">\
+        <li class="oa-dropdown-menu kn-dropdown-menu kn-button">\
+          <a href="#application-operating-authority/business-information/${recordId}/business-information/${recordId}" data-kn-slug="#application-operating-authority">\
+            <span class="nav-dropdown-link">${currentMenu}</span>\
+            <span class="kn-dropdown-icon fa fa-caret-down" />\
+          </a>\
+          <ul class="kn-dropdown-menu-list oa-dropdown-menu-list" style="min-width: 152px; margin: 0;">\
+            ${dropdownMenuItem(recordId, "application-operating-authority-service-type", "1 - Service Type")}\
+            ${dropdownMenuItem(recordId, "business-information", "2 - Business Information")}\
+            ${dropdownMenuItem(recordId, "insurance", "3 - Insurance")}\
+            ${dropdownMenuItem(recordId, "authorized-person", "4 - Authorized Person")}\
+            ${dropdownMenuItem(recordId, "application-operating-authority-vehicles", "5 - Vehicle Information")}\
+            ${dropdownMenuItem(recordId, "application-operating-authority-details", "6 - Review and Submit")}\
+          </ul>\
+    </div><br>`).appendTo("#view_" + key)
+  });
+}

--- a/code/mobility-services/mobility-services.js
+++ b/code/mobility-services/mobility-services.js
@@ -1,59 +1,127 @@
 /********************************************/
 /*************** Big Buttons ****************/
 /********************************************/
-function bigButton(id, view_id, url, fa_icon, button_label, target_blank = false, is_disabled = false, callback = null) {
+function bigButton(
+  id,
+  view_id,
+  url,
+  fa_icon,
+  button_label,
+  target_blank = false,
+  is_disabled = false,
+  callback = null
+) {
   var disabledClass = is_disabled ? " big-button-disabled'" : "'";
-  var newTab = target_blank ? " target='_blank'" : "" ;
-    $( "<a id='" + id + "' class='big-button-container" + disabledClass + " href='" + url + "'"
-      + newTab + "'><span><i class='fa fa-" + fa_icon + "'></i></span><span> " + button_label + "</span></a>" ).appendTo("#" + view_id);
+  var newTab = target_blank ? " target='_blank'" : "";
+  $(
+    "<a id='" +
+      id +
+      "' class='big-button-container" +
+      disabledClass +
+      " href='" +
+      url +
+      "'" +
+      newTab +
+      "'><span><i class='fa fa-" +
+      fa_icon +
+      "'></i></span><span> " +
+      button_label +
+      "</span></a>"
+  ).appendTo("#" + view_id);
   if (callback) callback();
 }
-	//>>>HOME TAB BUTTONS
-$(document).on('knack-view-render.view_11', function(event, page) {
+//>>>HOME TAB BUTTONS
+$(document).on("knack-view-render.view_11", function (event, page) {
   // create large AVAILABLE SERVICES button on the PORTAL page
-    bigButton('available-services', 'view_11', "https://atd.knack.com/mobility-services#available-services/", "list-ul", "Available Services");
+  bigButton(
+    "available-services",
+    "view_11",
+    "https://atd.knack.com/mobility-services#available-services/",
+    "list-ul",
+    "Available Services"
+  );
 });
-$(document).on('knack-view-render.view_16', function(event, page) {
+$(document).on("knack-view-render.view_16", function (event, page) {
   // create large CUSTOMER PORTAL button on the PORTAL page
-    bigButton('available-services', 'view_16', "https://atd.knack.com/mobility-services#portal/", "child", "Customer Portal");
+  bigButton(
+    "available-services",
+    "view_16",
+    "https://atd.knack.com/mobility-services#portal/",
+    "child",
+    "Customer Portal"
+  );
 });
-$(document).on('knack-view-render.view_34', function(event, page) {
+$(document).on("knack-view-render.view_34", function (event, page) {
   // create large REQUIRED DOCUMENTS button on the CHAUFFEUR page
-    bigButton('required-documents-chauffeur', 'view_34', "https://atd.knack.com/mobility-services#chauffeur-permit/required-documents-chauffeur/", "files-o", "Required Documents");
+  bigButton(
+    "required-documents-chauffeur",
+    "view_34",
+    "https://atd.knack.com/mobility-services#chauffeur-permit/required-documents-chauffeur/",
+    "files-o",
+    "Required Documents"
+  );
 });
-$(document).on('knack-view-render.view_36', function(event, page) {
+$(document).on("knack-view-render.view_36", function (event, page) {
   // create large START APPLICATION button on the CHAUFFEUR page
-    bigButton('start-application', 'view_36', "https://atd.knack.com/mobility-services#application-chauffeur/", "arrow-right", "Start Chauffeur Application");
+  bigButton(
+    "start-application",
+    "view_36",
+    "https://atd.knack.com/mobility-services#application-chauffeur/",
+    "arrow-right",
+    "Start Chauffeur Application"
+  );
 });
-$(document).on('knack-view-render.view_41', function(event, page) {
+$(document).on("knack-view-render.view_41", function (event, page) {
   // create large SIGN UP or Log-In button on the PORTAL page
-    bigButton('sign-up', 'view_41', "https://atd.knack.com/mobility-services#sign-up", "sign-in", "Sign up or Log In ");
+  bigButton(
+    "sign-up",
+    "view_41",
+    "https://atd.knack.com/mobility-services#sign-up",
+    "sign-in",
+    "Sign up or Log In "
+  );
 });
-$(document).on('knack-view-render.view_57', function(event, page) {
+$(document).on("knack-view-render.view_57", function (event, page) {
   // create large CUSTOMER PORTAL button on the PORTAL page
-    bigButton('available-services', 'view_57', "https://atd.knack.com/mobility-services#portal/", "arrow-right", "Mobility Services Portal");
+  bigButton(
+    "available-services",
+    "view_57",
+    "https://atd.knack.com/mobility-services#portal/",
+    "arrow-right",
+    "Mobility Services Portal"
+  );
 });
-$(document).on('knack-view-render.view_383', function(event, page) {
+$(document).on("knack-view-render.view_383", function (event, page) {
   // create large START APPLICATION button on the Operating Authority page
-    bigButton('start-application', 'view_383', "https://atd.knack.com/mobility-services#application-operating-authority", "arrow-right", "Start Operating Authority Application");
+  bigButton(
+    "start-application",
+    "view_383",
+    "https://atd.knack.com/mobility-services#application-operating-authority",
+    "arrow-right",
+    "Start Operating Authority Application"
+  );
 });
 
 /***************************************/
 /**** Input validation for SSN ********/
 /***************************************/
-$(document).on('knack-view-render.any', function (event, view, data) {
-  $('input#field_33').keyup(function(event) { // validates typing
-    this.value = this.value.replace(/[-]/g, ''); // replace hyphens with nothing
+$(document).on("knack-view-render.any", function (event, view, data) {
+  $("input#field_33").keyup(function (event) {
+    // validates typing
+    this.value = this.value.replace(/[-]/g, ""); // replace hyphens with nothing
 
-    if (event.key === 'Backspace') { // ignore if backspace
+    if (event.key === "Backspace") {
+      // ignore if backspace
       return;
-    } else if (event.key === ' ') { // reject " "
-      this.value = this.value.replace(/[\s]/g, ''); // replace space with nothing
-    } else if (isNaN(Number(event.key))) { // if not number
-      this.value = this.value.replace(/[^0-9\s-]+/g, '');
+    } else if (event.key === " ") {
+      // reject " "
+      this.value = this.value.replace(/[\s]/g, ""); // replace space with nothing
+    } else if (isNaN(Number(event.key))) {
+      // if not number
+      this.value = this.value.replace(/[^0-9\s-]+/g, "");
     }
   });
-  $("input#field_33").attr('maxlength', 4); // only max is 4 length
+  $("input#field_33").attr("maxlength", 4); // only max is 4 length
 });
 
 /********************************************************/
@@ -66,52 +134,54 @@ function showCharacterLimit(view_id, field_id, charLimit) {
     const fieldLength = inputField.val().length;
     var inputLength = Math.abs(charLimit - fieldLength); // No negative numbers
     var fieldText = fieldLength == 0 ? "allowed" : "left";
-    var cssField = {"color": "#4a4a4a", "font-weight": "normal"};
-    if (fieldLength > charLimit) { // if the length is over the character limit change the CSS and text
-      cssField = {"color": "#ff0000", "font-weight": "bold"}; // make text red and bold instead
+    var cssField = { color: "#4a4a4a", "font-weight": "normal" };
+    if (fieldLength > charLimit) {
+      // if the length is over the character limit change the CSS and text
+      cssField = { color: "#ff0000", "font-weight": "bold" }; // make text red and bold instead
       fieldText = "over limit"; // Will say "XXX characters over limit" instead
     }
-    return [inputLength + " characters " + fieldText,cssField]; // returns list as [str message, dict css]
+    return [inputLength + " characters " + fieldText, cssField]; // returns list as [str message, dict css]
   }
 
   /* Shows the message after field input based on character limit and length */
-  $(document).on("knack-view-render." + view_id, function(event, view, data) {
+  $(document).on("knack-view-render." + view_id, function (event, view, data) {
     /* When first viewing the field input */
-    const formViewFieldID = ".kn-form.kn-view."+ view_id + " form #" + field_id;
-    const fieldMessage = showMessage($(formViewFieldID))[0]; 
+    const formViewFieldID =
+      ".kn-form.kn-view." + view_id + " form #" + field_id;
+    const fieldMessage = showMessage($(formViewFieldID))[0];
     $(formViewFieldID).after(`<p class='typed-chars'>${fieldMessage}</p>`);
-    
+
     /* When user is typing in the input field change the text and CSS */
-    $(document).ready(function() { 
-      $(formViewFieldID).on('input',function(e){
+    $(document).ready(function () {
+      $(formViewFieldID).on("input", function (e) {
         const $input = $(this);
         const inputMessage = showMessage($input)[0];
         const cssField = showMessage($input)[1];
-        $input.siblings('.typed-chars').text(inputMessage); // Set text message of field
-        $input.siblings('.typed-chars').css(cssField); // Set CSS of typed-chars class
+        $input.siblings(".typed-chars").text(inputMessage); // Set text message of field
+        $input.siblings(".typed-chars").css(cssField); // Set CSS of typed-chars class
       });
     });
   });
-}; // This closes the showCharacterLimit function
+} // This closes the showCharacterLimit function
 
 const textBoxFieldIDs = [48, 49, 52, 53, 76, 86, 56]; // lists paragraph fields
 /* Character limit */
 for (let i = 0; i < textBoxFieldIDs.length; i++) {
-  showCharacterLimit('view_83','field_'+ textBoxFieldIDs[i],500); // background info page view
-  showCharacterLimit('view_155','field_'+ textBoxFieldIDs[i],500); // edit application page view
+  showCharacterLimit("view_83", "field_" + textBoxFieldIDs[i], 500); // background info page view
+  showCharacterLimit("view_155", "field_" + textBoxFieldIDs[i], 500); // edit application page view
 }
 
 /********************************************************/
 /** Relabel Attachment Links in Tables to 'Attachment' **/
 /********************************************************/
-$(document).on('knack-view-render.any', function(event, view, data) {
- $("a.kn-view-asset").html("View"); 
+$(document).on("knack-view-render.any", function (event, view, data) {
+  $("a.kn-view-asset").html("View");
 });
 
 /****************************************************/
 /*** Disable Trigger buttons from being Clickable ***/
 /****************************************************/
-$(document).on('knack-scene-render.any', function(event, view) {
+$(document).on("knack-scene-render.any", function (event, view) {
   var $disabledTriggerButton = $(".trigger-button-large-disabled").parent();
   $disabledTriggerButton.removeClass("kn-action-link");
 });
@@ -120,32 +190,37 @@ $(document).on('knack-scene-render.any', function(event, view) {
 /***** Print Menu Button ************/
 /***************************************/
 function printMenuButton(view_id) {
-  $('#' + view_id + ' .knMenuLink').click(function(e) {
+  $("#" + view_id + " .knMenuLink").click(function (e) {
     window.print();
   });
 }
 
 /* Print 3 pages menu view button - Chauffeur Permit*/
-$(document).on('knack-view-render.view_227', function(event, view, data) { // Customer Print
-  printMenuButton('view_227');
+$(document).on("knack-view-render.view_227", function (event, view, data) {
+  // Customer Print
+  printMenuButton("view_227");
 });
 
-$(document).on('knack-view-render.view_315', function(event, view, data) { // Reviewer Print
-  printMenuButton('view_315');
+$(document).on("knack-view-render.view_315", function (event, view, data) {
+  // Reviewer Print
+  printMenuButton("view_315");
 });
 
 /* Print 4 pages menu view button - Chauffeur Permit*/
-$(document).on('knack-view-render.view_228', function(event, view, data) { // Customer Print
-  printMenuButton('view_228');
+$(document).on("knack-view-render.view_228", function (event, view, data) {
+  // Customer Print
+  printMenuButton("view_228");
 });
 
-$(document).on('knack-view-render.view_304', function(event, view, data) { // Reviewer Print
-  printMenuButton('view_304'); 
+$(document).on("knack-view-render.view_304", function (event, view, data) {
+  // Reviewer Print
+  printMenuButton("view_304");
 });
 
 /* Print Operating Authority Notary Page */
-$(document).on('knack-view-render.view_480', function(event, view, data) { // Company Print
-  printMenuButton('view_480'); 
+$(document).on("knack-view-render.view_480", function (event, view, data) {
+  // Company Print
+  printMenuButton("view_480");
 });
 
 /***************************************
@@ -167,7 +242,13 @@ function customizeLoginButton(viewId) {
   $coacdButton.appendTo("#" + viewId);
 
   // Append Big SSO Login button and non-SSO Login button
-  bigButton("coacd-big-button", "coacd-button-login", url, "sign-in", "Sign-In")
+  bigButton(
+    "coacd-big-button",
+    "coacd-button-login",
+    url,
+    "sign-in",
+    "Sign-In"
+  );
 
   $coacdButton.append(
     "<a class='small-button' href='javascript:void(0)'>" +
@@ -204,38 +285,102 @@ $(document).on("knack-view-render.any", function (event, page) {
 /*** Dropdown Menu Buttons Navigation ***/
 /****************************************/
 function dropdownMenuItem(recordId, route, linkName) {
-  return (
-    `<li class="kn-button">\
+  return `<li class="kn-button">\
       <a href="#application-operating-authority/business-information/${recordId}/${route}/${recordId}">\
         <span>${linkName}</span>\
       </a>\
-    </li>`)
+    </li>`;
 }
 
-// Dictonary of views needing dropdown menu in editable Operating Authority (OA) pages
-var viewNameOA = {687:"1 - Service Type",676:"2 - Business Information",689:"3 - Insurance", 
-691:"4 - Authorized Person", 693:"5 - Vehicle Information", 695:"6 - Review and Submit"};
+// Dictionary of views needing dropdown menu in editable Operating Authority (OA) pages
+var viewNameOA = {
+  687: "1 - Service Type",
+  676: "2 - Business Information",
+  689: "3 - Insurance",
+  691: "4 - Authorized Person",
+  693: "5 - Vehicle Information",
+  695: "6 - Review and Submit",
+};
 
 for (let key in viewNameOA) {
-  $(document).on('knack-view-render.view_' + key, function(event, view, record) {
-    var recordId = view.scene.scene_id;
-    var currentMenu = viewNameOA[key];
+  $(document).on(
+    "knack-view-render.view_" + key,
+    function (event, view, record) {
+      var recordId = view.scene.scene_id;
+      var currentMenu = viewNameOA[key];
 
-    $(`<div class="details-dropdown-menu tabs">\
-      <ul id="oa-menu-list">\
-        <li class="oa-dropdown-menu kn-dropdown-menu kn-button">\
+      /* Desktop Operating Authority Page */
+      $(`<div class="details-dropdown-menu tabs">\
+      <ul id="desktop-menu-list">\
+        <li class="desktop-dropdown-menu kn-dropdown-menu kn-button">\
           <a href="#application-operating-authority/business-information/${recordId}/business-information/${recordId}" data-kn-slug="#application-operating-authority">\
             <span class="nav-dropdown-link">${currentMenu}</span>\
             <span class="kn-dropdown-icon fa fa-caret-down" />\
           </a>\
-          <ul class="kn-dropdown-menu-list oa-dropdown-menu-list" style="min-width: 152px; margin: 0;">\
-            ${dropdownMenuItem(recordId, "application-operating-authority-service-type", "1 - Service Type")}\
-            ${dropdownMenuItem(recordId, "business-information", "2 - Business Information")}\
+          <ul class="kn-dropdown-menu-list desktop-dropdown-menu-list" style="min-width: 152px; margin: 0;">\
+            ${dropdownMenuItem(
+              recordId,
+              "application-operating-authority-service-type",
+              "1 - Service Type"
+            )}\
+            ${dropdownMenuItem(
+              recordId,
+              "business-information",
+              "2 - Business Information"
+            )}\
             ${dropdownMenuItem(recordId, "insurance", "3 - Insurance")}\
-            ${dropdownMenuItem(recordId, "authorized-person", "4 - Authorized Person")}\
-            ${dropdownMenuItem(recordId, "application-operating-authority-vehicles", "5 - Vehicle Information")}\
-            ${dropdownMenuItem(recordId, "application-operating-authority-details", "6 - Review and Submit")}\
+            ${dropdownMenuItem(
+              recordId,
+              "authorized-person",
+              "4 - Authorized Person"
+            )}\
+            ${dropdownMenuItem(
+              recordId,
+              "application-operating-authority-vehicles",
+              "5 - Vehicle Information"
+            )}\
+            ${dropdownMenuItem(
+              recordId,
+              "application-operating-authority-details",
+              "6 - Review and Submit"
+            )}\
           </ul>\
-    </div><br>`).appendTo("#view_" + key)
-  });
+    </div><br>`).appendTo("#view_" + key);
+
+      /* Mobile Operating Authority Page */
+      $(`<div class="mobile-details-dropdown-menu">\
+    <ul id="mobile-menu-list">\
+      <li class="mobile-dropdown-menu">\
+        <ul class="desktop-dropdown-menu-list" style="min-width: 152px; margin: .5em;">\
+          ${dropdownMenuItem(
+            recordId,
+            "application-operating-authority-service-type",
+            "1 - Service Type"
+          )}\
+            ${dropdownMenuItem(
+              recordId,
+              "business-information",
+              "2 - Business Information"
+            )}\
+            ${dropdownMenuItem(recordId, "insurance", "3 - Insurance")}\
+            ${dropdownMenuItem(
+              recordId,
+              "authorized-person",
+              "4 - Authorized Person"
+            )}\
+            ${dropdownMenuItem(
+              recordId,
+              "application-operating-authority-vehicles",
+              "5 - Vehicle Information"
+            )}\
+            ${dropdownMenuItem(
+              recordId,
+              "application-operating-authority-details",
+              "6 - Review and Submit"
+            )}\
+      </li>\
+    </ul>\
+  </div><br>`).appendTo("#view_" + key);
+    }
+  );
 }

--- a/code/mobility-services/mobility-services.js
+++ b/code/mobility-services/mobility-services.js
@@ -1,105 +1,41 @@
 /********************************************/
 /*************** Big Buttons ****************/
 /********************************************/
-function bigButton(
-  id,
-  view_id,
-  url,
-  fa_icon,
-  button_label,
-  target_blank = false,
-  is_disabled = false,
-  callback = null
-) {
+function bigButton(id, view_id, url, fa_icon, button_label, target_blank = false, is_disabled = false, callback = null) {
   var disabledClass = is_disabled ? " big-button-disabled'" : "'";
-  var newTab = target_blank ? " target='_blank'" : "";
-  $(
-    "<a id='" +
-      id +
-      "' class='big-button-container" +
-      disabledClass +
-      " href='" +
-      url +
-      "'" +
-      newTab +
-      "'><span><i class='fa fa-" +
-      fa_icon +
-      "'></i></span><span> " +
-      button_label +
-      "</span></a>"
-  ).appendTo("#" + view_id);
+  var newTab = target_blank ? " target='_blank'" : "" ;
+    $( "<a id='" + id + "' class='big-button-container" + disabledClass + " href='" + url + "'"
+      + newTab + "'><span><i class='fa fa-" + fa_icon + "'></i></span><span> " + button_label + "</span></a>" ).appendTo("#" + view_id);
   if (callback) callback();
 }
-//>>>HOME TAB BUTTONS
-$(document).on("knack-view-render.view_11", function (event, page) {
+	//>>>HOME TAB BUTTONS
+$(document).on('knack-view-render.view_11', function(event, page) {
   // create large AVAILABLE SERVICES button on the PORTAL page
-  bigButton(
-    "available-services",
-    "view_11",
-    "https://atd.knack.com/mobility-services#available-services/",
-    "list-ul",
-    "Available Services"
-  );
+    bigButton('available-services', 'view_11', "https://atd.knack.com/mobility-services#available-services/", "list-ul", "Available Services");
 });
-$(document).on("knack-view-render.view_16", function (event, page) {
+$(document).on('knack-view-render.view_16', function(event, page) {
   // create large CUSTOMER PORTAL button on the PORTAL page
-  bigButton(
-    "available-services",
-    "view_16",
-    "https://atd.knack.com/mobility-services#portal/",
-    "child",
-    "Customer Portal"
-  );
+    bigButton('available-services', 'view_16', "https://atd.knack.com/mobility-services#portal/", "child", "Customer Portal");
 });
-$(document).on("knack-view-render.view_34", function (event, page) {
+$(document).on('knack-view-render.view_34', function(event, page) {
   // create large REQUIRED DOCUMENTS button on the CHAUFFEUR page
-  bigButton(
-    "required-documents-chauffeur",
-    "view_34",
-    "https://atd.knack.com/mobility-services#chauffeur-permit/required-documents-chauffeur/",
-    "files-o",
-    "Required Documents"
-  );
+    bigButton('required-documents-chauffeur', 'view_34', "https://atd.knack.com/mobility-services#chauffeur-permit/required-documents-chauffeur/", "files-o", "Required Documents");
 });
-$(document).on("knack-view-render.view_36", function (event, page) {
+$(document).on('knack-view-render.view_36', function(event, page) {
   // create large START APPLICATION button on the CHAUFFEUR page
-  bigButton(
-    "start-application",
-    "view_36",
-    "https://atd.knack.com/mobility-services#application-chauffeur/",
-    "arrow-right",
-    "Start Chauffeur Application"
-  );
+    bigButton('start-application', 'view_36', "https://atd.knack.com/mobility-services#application-chauffeur/", "arrow-right", "Start Chauffeur Application");
 });
-$(document).on("knack-view-render.view_41", function (event, page) {
+$(document).on('knack-view-render.view_41', function(event, page) {
   // create large SIGN UP or Log-In button on the PORTAL page
-  bigButton(
-    "sign-up",
-    "view_41",
-    "https://atd.knack.com/mobility-services#sign-up",
-    "sign-in",
-    "Sign up or Log In "
-  );
+    bigButton('sign-up', 'view_41', "https://atd.knack.com/mobility-services#sign-up", "sign-in", "Sign up or Log In ");
 });
-$(document).on("knack-view-render.view_57", function (event, page) {
+$(document).on('knack-view-render.view_57', function(event, page) {
   // create large CUSTOMER PORTAL button on the PORTAL page
-  bigButton(
-    "available-services",
-    "view_57",
-    "https://atd.knack.com/mobility-services#portal/",
-    "arrow-right",
-    "Mobility Services Portal"
-  );
+    bigButton('available-services', 'view_57', "https://atd.knack.com/mobility-services#portal/", "arrow-right", "Mobility Services Portal");
 });
-$(document).on("knack-view-render.view_383", function (event, page) {
+$(document).on('knack-view-render.view_383', function(event, page) {
   // create large START APPLICATION button on the Operating Authority page
-  bigButton(
-    "start-application",
-    "view_383",
-    "https://atd.knack.com/mobility-services#application-operating-authority",
-    "arrow-right",
-    "Start Operating Authority Application"
-  );
+    bigButton('start-application', 'view_383', "https://atd.knack.com/mobility-services#application-operating-authority", "arrow-right", "Start Operating Authority Application");
 });
 
 /***************************************/


### PR DESCRIPTION
This is related to https://github.com/cityofaustin/atd-data-tech/issues/20330 for **Step Indicator and Menu view in Operating Authority**.
The Dropdown Menu is documented here - https://atd-dts.gitbook.io/atd-knack-operations/knack-code/looks/dropdown-menu-buttons

Apologies that this is a lot since most of this was inherited from the earlier prototype github issue https://github.com/cityofaustin/atd-data-tech/issues/19617

<details open><summary><h1>Changes in JavaScript</h1></summary>
<details open><summary>Added Big Button for Operating Authority (currently hidden using a page rule where user role contains `Customer`)</summary>

   - Line 36-39 
<img src="https://github.com/user-attachments/assets/71f68398-95ee-46a0-a046-a9135fc0d32e" width=500>
</details>
<details open><summary>Update comment on menu views for print between Chauffeur Permit and Operating Authority</summary>

   - Line 124 and Line 133
</details>
<details open><summary>Added Print Menu Button for Operating Authority Notary</summary>

   - Line 146-150.
   - The recording it shows yellow/blue text for some reason in GIF but it does not look like that on browser.
![BA317EEF-FA14-45A0-9C9A-A4CA6BBE36FF](https://github.com/user-attachments/assets/bfd339b6-624b-4111-8d88-cbd11b0d37fd)
</details>
<details open><summary>Added Dropdown Menu View navigation </summary>

   - See GitBook documentation from TIA - https://atd-dts.gitbook.io/atd-knack-operations/knack-code/looks/dropdown-menu-buttons
   - Got the confirmation from Patrick to add it. The https://github.com/cityofaustin/atd-data-tech/issues/20330 goes over the old one with the menu view versus the dropdown menu view (note this was before CSS was added)
      - We talked about possibly having the link come from the step indicator but the amount of custom code needed and the step indicator not being scalable we shelved it for dropdown menu view as it already works in the TIA app
   - Some modifications from the JS include changing `tia` to `oa` naming
   - Using a dictionary for `{view_number:"Form Name"}` line 215-217 for the 6 pages that need the specific menu view.
   - Using a `for key in viewNameOA` in the dictionary for the six form pages starting from line 219-241
   - Added a `<br>` tag before the `appendTo` to fix visual spacing in line 239.
   - Removed icon styling to specify the step name. 
   - Tested all step indicator pages for menu view and it works as expected
![237DAB99-67E2-4EA9-BF31-A665580B3DED](https://github.com/user-attachments/assets/eda9e0cb-27d9-4c9c-91c1-4f4a99496ba7)
</details>
</details>

<details open><summary><h1>Changes in CSS</h1></summary>

- Added CSS for Operating Authority Step Indicator and Print page
- Line 197 was commented out to prevent a visual bug with the big trigger buttons in Chauffeur Permit.
- Added comment on line 49 to specify Chauffeur Permit
- Added class for `#oa` line 57-65 to change the width of step indicator . Width is based on how many steps and since the Chauffeur form is 4 steps while Operating Authority is 6 steps, I hade to change the width.
- Added Dropdown Menu CSS Line 240-286. Changed name of `tia` to `oa`
- Removed extra space in line 334
- Added print CSS to hide form when printing and hide text on web but allow on printing. This saves the applicant 1 click instead of 2. In Line 406-419
</details>