### PR TITLE
Update finance-purchasing.css

### DIFF
--- a/code/finance-puchasing/finance-purchasing.css
+++ b/code/finance-puchasing/finance-purchasing.css
@@ -130,3 +130,63 @@ a.small-button {
 .success-msg {
   background-color: #80d07e;
 }
+
+/*********************************************/
+/******** Header Banner Image Styling ********/
+/*********************************************/
+
+/* Base styles for the image */
+img.knHeader__logo-image {
+  width: 100% !important;
+  height: auto !important;
+  max-width: 100% !important;
+  object-fit: contain !important;
+}
+
+/* Base styles for the parent container */
+.knHeader__logo.knHeader__logo--custom {
+  height: auto !important;
+  max-width: 1000px !important;
+  margin: 0 0 0 0 !important; /* Left-justified */
+}
+
+/* Overrides for conflicting styles */
+.knHeader .knHeader__logo--custom {
+  width: 100% !important;
+  max-width: 1000px !important;
+  margin: 0 0 0 0 !important; /* Left-justified */
+}
+
+.knHeader .knHeader__logo .knHeader__logo-image {
+  width: 100% !important;
+  object-fit: contain !important;
+}
+
+/* Media queries for larger screens */
+@media (min-width: 768px) {
+  .knHeader__logo.knHeader__logo--custom {
+    width: 80% !important;
+  }
+}
+
+@media (min-width: 1024px) {
+  .knHeader__logo.knHeader__logo--custom {
+    width: 80% !important; /* Medium width on large screens */
+    max-width: 1000px !important;
+  }
+}
+
+/* Media queries for image resizing */
+@media (max-width: 767px) {
+  .knHeader__logo.knHeader__logo--custom {
+    width: 100% !important; /* Full width on small screens */
+    max-width: 600px !important;
+  }
+}
+
+@media (min-width: 768px) and (max-width: 1023px) {
+  .knHeader__logo.knHeader__logo--custom {
+    width: 80% !important; /* Medium width on medium screens */
+    max-width: 800px !important;
+  }
+}


### PR DESCRIPTION
Updating knack application banners - mobile responsive

New .css code lines 134-192

## Before
![image](https://github.com/user-attachments/assets/fc29e870-c6b2-417a-b1ff-7266e9f353ca)

## After
![image](https://github.com/user-attachments/assets/212f4ff3-8174-4e03-a574-25576fff305d)

## Side by Side
Left (new), Right (original) - the new banner has resized based on the screen width
![image](https://github.com/user-attachments/assets/f93a00b8-2577-40cb-aef0-ba7e0332b87f)

## Mobile Sizing
### Before
the old banner would get cut off in mobile environments and the user would have to scroll to access the mobile navigation menu
![image](https://github.com/user-attachments/assets/d2efbfa7-952a-4089-8586-8cda27fb37ea)

### After
the new banner has resized based on the screen width, iPhone SE
![image](https://github.com/user-attachments/assets/4b1863d3-ab8a-4121-89cb-5554f48f0cf9)

