### PR TITLE
[Traffic Register] View PDF Buttons CSS Styling & JQuery Functionality

### DIFF
--- a/code/traffic-register/traffic-register.css
+++ b/code/traffic-register/traffic-register.css
@@ -455,34 +455,34 @@ a.ang-link:link {text-decoration: none;}
 /*** Style Details Links as Buttons ***/
 /**************************************/
 /*These are for View PDF Buttons*/
-/*Reg Doc Details Header navigating from Document Search - Generated PowerBI PDF*/
+/*Reg Doc Details Header navigating from Document Search - Generated Power BI PDF*/
 #kn-scene_588 #view_1476 div.kn-detail { padding: 1px 2px; border-style: solid; border-width: 1px; border-color: #dd4d4d; border-radius: 8px; 
   box-shadow: 0px 0px 0px 0px gray; font-size: 1.25em; background-color: #ebebeb; color: #163f6e; text-align: left; min-width: 190px !important; max-width: 27% !important; }
-#kn-scene_588 #view_1476 div.kn-detail:hover { opacity: 0.9; cursor: pointer; border-color: #dd4d4d; border-width: 2px; min-width: 190px !important; max-width: 27% !important; }
+#kn-scene_588 #view_1476 div.kn-detail:hover { opacity: 0.9; cursor: pointer; border-color: #dd4d4d; border-width: 2px; }
 #kn-scene_588 #view_1476 .kn-detail-label { background-color: transparent; min-width: 0% !important; }
 
 /*Reg Doc Details Header navigating from Document Search - Historical SharePoint PDF*/
 #kn-scene_588 #view_1706 div.kn-detail { padding: 1px 2px; border-style: solid; border-width: 1px; border-color: #163f6e; border-radius: 8px; 
   box-shadow: 0px 0px 0px 0px gray; font-size: 1.25em; background-color: #ebebeb; color: #163f6e; text-align: left; min-width: 190px !important; max-width: 27% !important; }
-#kn-scene_588 #view_1706 div.kn-detail:hover { opacity: 0.9; cursor: pointer; border-color: #163f6e; border-width: 2px; min-width: 190px !important; max-width: 27% !important; }
+#kn-scene_588 #view_1706 div.kn-detail:hover { opacity: 0.9; cursor: pointer; border-color: #163f6e; border-width: 2px; }
 #kn-scene_588 #view_1706 .kn-detail-label { background-color: transparent; min-width: 0% !important; }
 
-/*Reg Doc Details Header navigating from Regulations Search - Generated PowerBI PDF*/
+/*Reg Doc Details Header navigating from Regulations Search - Generated Power BI PDF*/
 #kn-scene_773 #view_1592 div.kn-detail { padding: 1px 2px; border-style: solid; border-width: 1px; border-color: #dd4d4d; border-radius: 8px; 
   box-shadow: 0px 0px 0px 0px gray; font-size: 1.25em; background-color: #ebebeb; color: #163f6e; text-align: left; min-width: 190px !important; max-width: 27% !important; }
-#kn-scene_773 #view_1592 div.kn-detail:hover { opacity: 0.9; cursor: pointer; border-color: #dd4d4d; border-width: 2px; min-width: 190px !important; max-width: 27% !important; }
+#kn-scene_773 #view_1592 div.kn-detail:hover { opacity: 0.9; cursor: pointer; border-color: #dd4d4d; border-width: 2px; }
 #kn-scene_773 #view_1592 .kn-detail-label { background-color: transparent; min-width: 0% !important; }
 
 /*Reg Doc Details Header navigating from Regulations Search - Historical SharePoint PDF*/
 #kn-scene_773 #view_1705 div.kn-detail { padding: 1px 2px; border-style: solid; border-width: 1px; border-color: #163f6e; border-radius: 8px; 
   box-shadow: 0px 0px 0px 0px gray; font-size: 1.25em; background-color: #ebebeb; color: #163f6e; text-align: left; min-width: 190px !important; max-width: 27% !important; }
-#kn-scene_773 #view_1705 div.kn-detail:hover { opacity: 0.9; cursor: pointer; border-color: #163f6e; border-width: 2px; min-width: 190px !important; max-width: 27% !important; }
+#kn-scene_773 #view_1705 div.kn-detail:hover { opacity: 0.9; cursor: pointer; border-color: #163f6e; border-width: 2px; }
 #kn-scene_773 #view_1705 .kn-detail-label { background-color: transparent; min-width: 0% !important; }
 
 /*Draft Review Details Header*/
 #kn-scene_673 #view_1478 div.kn-detail { padding: 1px 2px; border-style: solid; border-width: 1px; border-color: #dd4d4d; border-radius: 8px; 
   box-shadow: 0px 0px 0px 0px gray; font-size: 1.25em; background-color: #ebebeb; color: #163f6e; text-align: left; min-width: 190px !important; max-width: 27% !important; }
-#kn-scene_673 #view_1478 div.kn-detail:hover { opacity: 0.9; cursor: pointer; border-color: #dd4d4d; border-width: 2px; min-width: 190px !important; max-width: 27% !important; }
+#kn-scene_673 #view_1478 div.kn-detail:hover { opacity: 0.9; cursor: pointer; border-color: #dd4d4d; border-width: 2px; }
 #kn-scene_673 #view_1478 .kn-detail-label { background-color: transparent; min-width: 0% !important; }
 
 /*****************************************/

--- a/code/traffic-register/traffic-register.css
+++ b/code/traffic-register/traffic-register.css
@@ -455,17 +455,29 @@ a.ang-link:link {text-decoration: none;}
 /*** Style Details Links as Buttons ***/
 /**************************************/
 /*These are for View PDF Buttons*/
-/*Reg Doc Details Header navigating from Document Search*/
+/*Reg Doc Details Header navigating from Document Search - Generated PowerBI PDF*/
 #kn-scene_588 #view_1476 div.kn-detail { padding: 1px 2px; border-style: solid; border-width: 1px; border-color: #dd4d4d; border-radius: 8px; 
   box-shadow: 0px 0px 0px 0px gray; font-size: 1.25em; background-color: #ebebeb; color: #163f6e; text-align: left; min-width: 190px !important; max-width: 27% !important; }
 #kn-scene_588 #view_1476 div.kn-detail:hover { opacity: 0.9; cursor: pointer; border-color: #dd4d4d; border-width: 2px; min-width: 190px !important; max-width: 27% !important; }
 #kn-scene_588 #view_1476 .kn-detail-label { background-color: transparent; min-width: 0% !important; }
 
-/*Reg Doc Details Header navigating from Regulations Search*/
+/*Reg Doc Details Header navigating from Document Search - Historical SharePoint PDF*/
+#kn-scene_588 #view_1706 div.kn-detail { padding: 1px 2px; border-style: solid; border-width: 1px; border-color: #163f6e; border-radius: 8px; 
+  box-shadow: 0px 0px 0px 0px gray; font-size: 1.25em; background-color: #ebebeb; color: #163f6e; text-align: left; min-width: 190px !important; max-width: 27% !important; }
+#kn-scene_588 #view_1706 div.kn-detail:hover { opacity: 0.9; cursor: pointer; border-color: #163f6e; border-width: 2px; min-width: 190px !important; max-width: 27% !important; }
+#kn-scene_588 #view_1706 .kn-detail-label { background-color: transparent; min-width: 0% !important; }
+
+/*Reg Doc Details Header navigating from Regulations Search - Generated PowerBI PDF*/
 #kn-scene_773 #view_1592 div.kn-detail { padding: 1px 2px; border-style: solid; border-width: 1px; border-color: #dd4d4d; border-radius: 8px; 
   box-shadow: 0px 0px 0px 0px gray; font-size: 1.25em; background-color: #ebebeb; color: #163f6e; text-align: left; min-width: 190px !important; max-width: 27% !important; }
 #kn-scene_773 #view_1592 div.kn-detail:hover { opacity: 0.9; cursor: pointer; border-color: #dd4d4d; border-width: 2px; min-width: 190px !important; max-width: 27% !important; }
 #kn-scene_773 #view_1592 .kn-detail-label { background-color: transparent; min-width: 0% !important; }
+
+/*Reg Doc Details Header navigating from Regulations Search - Historical SharePoint PDF*/
+#kn-scene_773 #view_1705 div.kn-detail { padding: 1px 2px; border-style: solid; border-width: 1px; border-color: #163f6e; border-radius: 8px; 
+  box-shadow: 0px 0px 0px 0px gray; font-size: 1.25em; background-color: #ebebeb; color: #163f6e; text-align: left; min-width: 190px !important; max-width: 27% !important; }
+#kn-scene_773 #view_1705 div.kn-detail:hover { opacity: 0.9; cursor: pointer; border-color: #163f6e; border-width: 2px; min-width: 190px !important; max-width: 27% !important; }
+#kn-scene_773 #view_1705 .kn-detail-label { background-color: transparent; min-width: 0% !important; }
 
 /*Draft Review Details Header*/
 #kn-scene_673 #view_1478 div.kn-detail { padding: 1px 2px; border-style: solid; border-width: 1px; border-color: #dd4d4d; border-radius: 8px; 

--- a/code/traffic-register/traffic-register.css
+++ b/code/traffic-register/traffic-register.css
@@ -454,36 +454,51 @@ a.ang-link:link {text-decoration: none;}
 /**************************************/
 /*** Style Details Links as Buttons ***/
 /**************************************/
-/*These are for View PDF Buttons*/
+/* These are for View PDF Buttons */
 /*Reg Doc Details Header navigating from Document Search - Generated Power BI PDF*/
-#kn-scene_588 #view_1476 div.kn-detail { padding: 1px 2px; border-style: solid; border-width: 1px; border-color: #dd4d4d; border-radius: 8px; 
+/* #kn-scene_588 #view_1476 div.kn-detail { padding: 1px 2px; border-style: solid; border-width: 1px; border-color: #dd4d4d; border-radius: 8px; 
   box-shadow: 0px 0px 0px 0px gray; font-size: 1.25em; background-color: #ebebeb; color: #163f6e; text-align: left; min-width: 190px !important; max-width: 27% !important; }
 #kn-scene_588 #view_1476 div.kn-detail:hover { opacity: 0.9; cursor: pointer; border-color: #dd4d4d; border-width: 2px; }
-#kn-scene_588 #view_1476 .kn-detail-label { background-color: transparent; min-width: 0% !important; }
+#kn-scene_588 #view_1476 .kn-detail-label { background-color: transparent; min-width: 0% !important; } */
 
 /*Reg Doc Details Header navigating from Document Search - Historical SharePoint PDF*/
-#kn-scene_588 #view_1706 div.kn-detail { padding: 1px 2px; border-style: solid; border-width: 1px; border-color: #163f6e; border-radius: 8px; 
+/* #kn-scene_588 #view_1706 div.kn-detail { padding: 1px 2px; border-style: solid; border-width: 1px; border-color: #163f6e; border-radius: 8px; 
   box-shadow: 0px 0px 0px 0px gray; font-size: 1.25em; background-color: #ebebeb; color: #163f6e; text-align: left; min-width: 190px !important; max-width: 27% !important; }
 #kn-scene_588 #view_1706 div.kn-detail:hover { opacity: 0.9; cursor: pointer; border-color: #163f6e; border-width: 2px; }
-#kn-scene_588 #view_1706 .kn-detail-label { background-color: transparent; min-width: 0% !important; }
+#kn-scene_588 #view_1706 .kn-detail-label { background-color: transparent; min-width: 0% !important; } */
 
 /*Reg Doc Details Header navigating from Regulations Search - Generated Power BI PDF*/
-#kn-scene_773 #view_1592 div.kn-detail { padding: 1px 2px; border-style: solid; border-width: 1px; border-color: #dd4d4d; border-radius: 8px; 
+/* #kn-scene_773 #view_1592 div.kn-detail { padding: 1px 2px; border-style: solid; border-width: 1px; border-color: #dd4d4d; border-radius: 8px; 
   box-shadow: 0px 0px 0px 0px gray; font-size: 1.25em; background-color: #ebebeb; color: #163f6e; text-align: left; min-width: 190px !important; max-width: 27% !important; }
 #kn-scene_773 #view_1592 div.kn-detail:hover { opacity: 0.9; cursor: pointer; border-color: #dd4d4d; border-width: 2px; }
-#kn-scene_773 #view_1592 .kn-detail-label { background-color: transparent; min-width: 0% !important; }
+#kn-scene_773 #view_1592 .kn-detail-label { background-color: transparent; min-width: 0% !important; } */
 
 /*Reg Doc Details Header navigating from Regulations Search - Historical SharePoint PDF*/
-#kn-scene_773 #view_1705 div.kn-detail { padding: 1px 2px; border-style: solid; border-width: 1px; border-color: #163f6e; border-radius: 8px; 
+/* #kn-scene_773 #view_1705 div.kn-detail { padding: 1px 2px; border-style: solid; border-width: 1px; border-color: #163f6e; border-radius: 8px; 
   box-shadow: 0px 0px 0px 0px gray; font-size: 1.25em; background-color: #ebebeb; color: #163f6e; text-align: left; min-width: 190px !important; max-width: 27% !important; }
 #kn-scene_773 #view_1705 div.kn-detail:hover { opacity: 0.9; cursor: pointer; border-color: #163f6e; border-width: 2px; }
-#kn-scene_773 #view_1705 .kn-detail-label { background-color: transparent; min-width: 0% !important; }
+#kn-scene_773 #view_1705 .kn-detail-label { background-color: transparent; min-width: 0% !important; } */
 
 /*Draft Review Details Header*/
 #kn-scene_673 #view_1478 div.kn-detail { padding: 1px 2px; border-style: solid; border-width: 1px; border-color: #dd4d4d; border-radius: 8px; 
   box-shadow: 0px 0px 0px 0px gray; font-size: 1.25em; background-color: #ebebeb; color: #163f6e; text-align: left; min-width: 190px !important; max-width: 27% !important; }
 #kn-scene_673 #view_1478 div.kn-detail:hover { opacity: 0.9; cursor: pointer; border-color: #dd4d4d; border-width: 2px; }
 #kn-scene_673 #view_1478 .kn-detail-label { background-color: transparent; min-width: 0% !important; }
+
+/****************************************/
+/*** Style PDF Link Fields as Buttons ***/
+/****************************************/
+div.kn-detail.field_1729 { padding: 1px 2px; border-style: solid; border-width: 1px; border-color: #dd4d4d; border-radius: 8px; 
+  box-shadow: 0px 0px 0px 0px gray; font-size: 1.25em; background-color: #ebebeb; color: #163f6e; text-align: left; min-width: 190px !important; max-width: 27% !important; }
+div.kn-detail:hover.field_1729 { opacity: 0.9; cursor: pointer; border-color: #dd4d4d; border-width: 2px; }
+div.kn-detail.field_1729 .kn-detail-label { background-color: transparent; min-width: 0% !important; }
+.pbi-link {text-decoration: none !important;} /*the CSS Class we apply to the anchor with JQuery. Overrides default .kn-content a*/
+
+div.kn-detail.field_1778 { padding: 1px 2px; border-style: solid; border-width: 1px; border-color: #163f6e; border-radius: 8px; 
+  box-shadow: 0px 0px 0px 0px gray; font-size: 1.25em; background-color: #ebebeb; color: #163f6e; text-align: left; min-width: 190px !important; max-width: 27% !important; }
+div.kn-detail:hover.field_1778 { opacity: 0.9; cursor: pointer; border-color: #163f6e; border-width: 2px; }
+div.kn-detail.field_1778 .kn-detail-label { background-color: transparent; min-width: 0% !important; }
+.sp-link {text-decoration: none !important;} /*the CSS Class we apply to the anchor with JQuery. Overrides default .kn-content a*/
 
 /*****************************************/
 /** Remove Back Links for Draft Builder **/

--- a/code/traffic-register/traffic-register.js
+++ b/code/traffic-register/traffic-register.js
@@ -236,3 +236,24 @@ $(document).on('knack-scene-render.scene_707', function(event, scene) {
 $(document).on('knack-scene-render.scene_708', function(event, scene) {
     $('#kn-app-menu').hide()
 });
+
+/*********************************************/
+/************** PDF Button link **************/
+/*********************************************/
+$(document).on('knack-scene-render.any', function(event, scene) {
+  $(".kn-detail.field_1729 a").addClass("pbi-link");                      /*Add CSS Class pbi-link to child anchor*/
+  $(".kn-detail.field_1729").wrap("<div class='pbi-link-button'></div>"); /*Wrap the div with div class pbi-link-button*/
+  $(".pbi-link-button").click(function(){                                 /*Add click event to the new div*/
+	  window.open($(this).find("a").attr("href"), '_blank');                /*Click event uses link from child anchor & opens in new tab*/
+		return false;
+	});
+});
+
+$(document).on('knack-scene-render.any', function(event, scene) {
+  $(".kn-detail.field_1778 a").addClass("sp-link");                      /*Add CSS Class sp-link to child anchor*/
+  $(".kn-detail.field_1778").wrap("<div class='sp-link-button'></div>"); /*Wrap the div with div class sp-link-button*/
+  $(".sp-link-button").click(function(){                                 /*Add click event to the new div*/
+	  window.open($(this).find("a").attr("href"), '_blank');               /*Click event uses link from child anchor & opens in new tab*/
+		return false;
+	});
+});


### PR DESCRIPTION
For [#20611](https://github.com/cityofaustin/atd-data-tech/issues/20611)

Using the same styling as the View PDF buttons for generated PDF's stored in PowerBI, we create View PDF buttons for historical PDF's stored in SharePoint. We use a blue outline for these historical buttons to create distinction.

![image](https://github.com/user-attachments/assets/e3c03b42-3bea-438b-8a26-6781f477ecb9)

New with JQuery:
![image](https://github.com/user-attachments/assets/c9fd3ca5-b12f-4e54-a066-8d3e23221415)

