### PR TITLE
Added delete trigger button CSS styling on Edit Plant form in OCE app

### DIFF
--- a/code/office-city-engineer/oce.css
+++ b/code/office-city-engineer/oce.css
@@ -2,122 +2,145 @@
 /************* Big Buttons *************/
 /***************************************/
 .big-button-container {
-  padding: 20px 20px;
-  border-radius: 4px;
-  box-shadow: 0px 1px 2px 0px gray;
-  font-size: 2.5em;
-  max-width: 15em;
-  display: block;
-}
-
-.big-button-container:hover {
-  background-color: #f7f7f7;
-  cursor: pointer;
-}
-
-.big-button-disabled {
-  background-color: #f7f7f7;
-  opacity: 0.6;
-  pointer-events: none;
-}
-
-a.big-button-container {
-  text-decoration: none;
-}
-/***************************************/
-/************ Small Buttons ************/
-/***************************************/
-.small-button-container {
-  padding: 5px 10px;
-  margin: 10px;
-  border-radius: 4px;
-  box-shadow: 0px 1px 2px 0px gray;
-  font-size: 1em;
-  max-width: 15em;
-  background-color: #babbbc;
-  color: white;
-}
-
-.small-button-container:hover {
-  background-color: #4c4c4c;
-  cursor: pointer;
-}
-
-.small-button-disabled {
-  background-color: #f7f7f7;
-  opacity: 0.6;
-}
-
-a.small-button {
-  text-decoration: none;
-}
-
-/****************************************/
-/************ Button Effects ************/
-/****************************************/
-.disabled { cursor: not-allowed; }
-
-/***************************************/
-/********* FA Icon Positioning *********/
-/***************************************/
-.fa { vertical-align: baseline; }
-
-/*********************************************/
-/******** Header Banner Image Styling ********/
-/*********************************************/
-
-/* Base styles for the image */
-img.knHeader__logo-image {
-  width: 100% !important;
-  height: auto !important;
-  max-width: 100% !important;
-  object-fit: contain !important;
-}
-
-/* Base styles for the parent container */
-.knHeader__logo.knHeader__logo--custom {
-  height: auto !important;
-  max-width: 1000px !important;
-  margin: 0 0 0 0 !important; /* Left-justified */
-}
-
-/* Overrides for conflicting styles */
-.knHeader .knHeader__logo--custom {
-  width: 100% !important;
-  max-width: 1000px !important;
-  margin: 0 0 0 0 !important; /* Left-justified */
-}
-
-.knHeader .knHeader__logo .knHeader__logo-image {
-  width: 100% !important;
-  object-fit: contain !important;
-}
-
-/* Media queries for larger screens */
-@media (min-width: 768px) {
-  .knHeader__logo.knHeader__logo--custom {
-    width: 80% !important;
+    padding: 20px 20px;
+    border-radius: 4px;
+    box-shadow: 0px 1px 2px 0px gray;
+    font-size: 2.5em;
+    max-width: 15em;
+    display: block;
   }
-}
-
-@media (min-width: 1024px) {
+  
+  .big-button-container:hover {
+    background-color: #f7f7f7;
+    cursor: pointer;
+  }
+  
+  .big-button-disabled {
+    background-color: #f7f7f7;
+    opacity: 0.6;
+    pointer-events: none;
+  }
+  
+  a.big-button-container {
+    text-decoration: none;
+  }
+  /***************************************/
+  /************ Small Buttons ************/
+  /***************************************/
+  .small-button-container {
+    padding: 5px 10px;
+    margin: 10px;
+    border-radius: 4px;
+    box-shadow: 0px 1px 2px 0px gray;
+    font-size: 1em;
+    max-width: 15em;
+    background-color: #babbbc;
+    color: white;
+  }
+  
+  .small-button-container:hover {
+    background-color: #4c4c4c;
+    cursor: pointer;
+  }
+  
+  .small-button-disabled {
+    background-color: #f7f7f7;
+    opacity: 0.6;
+  }
+  
+  a.small-button {
+    text-decoration: none;
+  }
+  
+  /****************************************/
+  /************ Button Effects ************/
+  /****************************************/
+  .disabled { cursor: not-allowed; }
+  
+  /***************************************/
+  /********* FA Icon Positioning *********/
+  /***************************************/
+  .fa { vertical-align: baseline; }
+  
+  /***************************************/
+  /*********** Trigger Buttons ***********/
+  /***************************************/
+  /* Delete Button styling */
+  .trigger-button-delete {
+    border-style: solid;
+    border-width: 1px;
+    border-color: #EB4133;
+    border-radius: 4px;
+    box-shadow: 0px 0px 0px 0px gray;
+    background-color: #EB4133;
+    color: #FFFFFF;
+    padding: 1px 10px;
+    text-align: center;
+    display: inline-block;
+  }
+  
+  .trigger-button-delete:hover {
+    cursor: pointer;
+    opacity: 0.9;
+    filter: brightness(95%);
+  }
+  
+  /*********************************************/
+  /******** Header Banner Image Styling ********/
+  /*********************************************/
+  
+  /* Base styles for the image */
+  img.knHeader__logo-image {
+    width: 100% !important;
+    height: auto !important;
+    max-width: 100% !important;
+    object-fit: contain !important;
+  }
+  
+  /* Base styles for the parent container */
   .knHeader__logo.knHeader__logo--custom {
-    width: 80% !important; /* Medium width on large screens */
+    height: auto !important;
     max-width: 1000px !important;
+    margin: 0 0 0 0 !important; /* Left-justified */
   }
-}
-
-/* Media queries for image resizing */
-@media (max-width: 767px) {
-  .knHeader__logo.knHeader__logo--custom {
-    width: 100% !important; /* Full width on small screens */
-    max-width: 600px !important;
+  
+  /* Overrides for conflicting styles */
+  .knHeader .knHeader__logo--custom {
+    width: 100% !important;
+    max-width: 1000px !important;
+    margin: 0 0 0 0 !important; /* Left-justified */
   }
-}
-
-@media (min-width: 768px) and (max-width: 1023px) {
-  .knHeader__logo.knHeader__logo--custom {
-    width: 80% !important; /* Medium width on medium screens */
-    max-width: 800px !important;
+  
+  .knHeader .knHeader__logo .knHeader__logo-image {
+    width: 100% !important;
+    object-fit: contain !important;
   }
-}
+  
+  /* Media queries for larger screens */
+  @media (min-width: 768px) {
+    .knHeader__logo.knHeader__logo--custom {
+      width: 80% !important;
+    }
+  }
+  
+  @media (min-width: 1024px) {
+    .knHeader__logo.knHeader__logo--custom {
+      width: 80% !important; /* Medium width on large screens */
+      max-width: 1000px !important;
+    }
+  }
+  
+  /* Media queries for image resizing */
+  @media (max-width: 767px) {
+    .knHeader__logo.knHeader__logo--custom {
+      width: 100% !important; /* Full width on small screens */
+      max-width: 600px !important;
+    }
+  }
+  
+  @media (min-width: 768px) and (max-width: 1023px) {
+    .knHeader__logo.knHeader__logo--custom {
+      width: 80% !important; /* Medium width on medium screens */
+      max-width: 800px !important;
+    }
+  }

--- a/code/office-city-engineer/oce.css
+++ b/code/office-city-engineer/oce.css
@@ -2,143 +2,143 @@
 /************* Big Buttons *************/
 /***************************************/
 .big-button-container {
-    padding: 20px 20px;
-    border-radius: 4px;
-    box-shadow: 0px 1px 2px 0px gray;
-    font-size: 2.5em;
-    max-width: 15em;
-    display: block;
-  }
-  
-  .big-button-container:hover {
-    background-color: #f7f7f7;
-    cursor: pointer;
-  }
-  
-  .big-button-disabled {
-    background-color: #f7f7f7;
-    opacity: 0.6;
-    pointer-events: none;
-  }
-  
-  a.big-button-container {
-    text-decoration: none;
-  }
-  /***************************************/
-  /************ Small Buttons ************/
-  /***************************************/
-  .small-button-container {
-    padding: 5px 10px;
-    margin: 10px;
-    border-radius: 4px;
-    box-shadow: 0px 1px 2px 0px gray;
-    font-size: 1em;
-    max-width: 15em;
-    background-color: #babbbc;
-    color: white;
-  }
-  
-  .small-button-container:hover {
-    background-color: #4c4c4c;
-    cursor: pointer;
-  }
-  
-  .small-button-disabled {
-    background-color: #f7f7f7;
-    opacity: 0.6;
-  }
-  
-  a.small-button {
-    text-decoration: none;
-  }
-  
-  /****************************************/
-  /************ Button Effects ************/
-  /****************************************/
-  .disabled { cursor: not-allowed; }
-  
-  /***************************************/
-  /********* FA Icon Positioning *********/
-  /***************************************/
-  .fa { vertical-align: baseline; }
-  
-  /***************************************/
-  /*********** Trigger Buttons ***********/
-  /***************************************/
-  /* Delete Button styling */
-  .trigger-button-delete {
-    border-width: 1px;
-    border-color: transparent;
-    border-radius: 4px;
-    box-shadow: 0px 0px 0px 0px gray;
-    background-color: #E41A1C;
-    color: #FFFFFF;
-    padding: 1px 10px;
-    text-align: center;
-    display: inline-block;
-  }
-  
-  .trigger-button-delete:hover {
-    cursor: pointer;
-    opacity: 0.9;
-  }
-  
-  /*********************************************/
-  /******** Header Banner Image Styling ********/
-  /*********************************************/
-  
-  /* Base styles for the image */
-  img.knHeader__logo-image {
-    width: 100% !important;
-    height: auto !important;
-    max-width: 100% !important;
-    object-fit: contain !important;
-  }
-  
-  /* Base styles for the parent container */
+  padding: 20px 20px;
+  border-radius: 4px;
+  box-shadow: 0px 1px 2px 0px gray;
+  font-size: 2.5em;
+  max-width: 15em;
+  display: block;
+}
+
+.big-button-container:hover {
+  background-color: #f7f7f7;
+  cursor: pointer;
+}
+
+.big-button-disabled {
+  background-color: #f7f7f7;
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+a.big-button-container {
+  text-decoration: none;
+}
+/***************************************/
+/************ Small Buttons ************/
+/***************************************/
+.small-button-container {
+  padding: 5px 10px;
+  margin: 10px;
+  border-radius: 4px;
+  box-shadow: 0px 1px 2px 0px gray;
+  font-size: 1em;
+  max-width: 15em;
+  background-color: #babbbc;
+  color: white;
+}
+
+.small-button-container:hover {
+  background-color: #4c4c4c;
+  cursor: pointer;
+}
+
+.small-button-disabled {
+  background-color: #f7f7f7;
+  opacity: 0.6;
+}
+
+a.small-button {
+  text-decoration: none;
+}
+
+/****************************************/
+/************ Button Effects ************/
+/****************************************/
+.disabled { cursor: not-allowed; }
+
+/***************************************/
+/********* FA Icon Positioning *********/
+/***************************************/
+.fa { vertical-align: baseline; }
+
+/***************************************/
+/*********** Trigger Buttons ***********/
+/***************************************/
+/* Delete Trigger Button styling */
+.trigger-button-delete {
+  border-width: 1px;
+  border-color: transparent;
+  border-radius: 4px;
+  box-shadow: 0px 0px 0px 0px gray;
+  background-color: #E41A1C;
+  color: #FFFFFF;
+  padding: 1px 10px;
+  text-align: center;
+  display: inline-block;
+}
+
+.trigger-button-delete:hover {
+  cursor: pointer;
+  opacity: 0.9;
+}
+
+/*********************************************/
+/******** Header Banner Image Styling ********/
+/*********************************************/
+
+/* Base styles for the image */
+img.knHeader__logo-image {
+  width: 100% !important;
+  height: auto !important;
+  max-width: 100% !important;
+  object-fit: contain !important;
+}
+
+/* Base styles for the parent container */
+.knHeader__logo.knHeader__logo--custom {
+  height: auto !important;
+  max-width: 1000px !important;
+  margin: 0 0 0 0 !important; /* Left-justified */
+}
+
+/* Overrides for conflicting styles */
+.knHeader .knHeader__logo--custom {
+  width: 100% !important;
+  max-width: 1000px !important;
+  margin: 0 0 0 0 !important; /* Left-justified */
+}
+
+.knHeader .knHeader__logo .knHeader__logo-image {
+  width: 100% !important;
+  object-fit: contain !important;
+}
+
+/* Media queries for larger screens */
+@media (min-width: 768px) {
   .knHeader__logo.knHeader__logo--custom {
-    height: auto !important;
+    width: 80% !important;
+  }
+}
+
+@media (min-width: 1024px) {
+  .knHeader__logo.knHeader__logo--custom {
+    width: 80% !important; /* Medium width on large screens */
     max-width: 1000px !important;
-    margin: 0 0 0 0 !important; /* Left-justified */
   }
-  
-  /* Overrides for conflicting styles */
-  .knHeader .knHeader__logo--custom {
-    width: 100% !important;
-    max-width: 1000px !important;
-    margin: 0 0 0 0 !important; /* Left-justified */
+}
+
+/* Media queries for image resizing */
+@media (max-width: 767px) {
+  .knHeader__logo.knHeader__logo--custom {
+    width: 100% !important; /* Full width on small screens */
+    max-width: 600px !important;
   }
-  
-  .knHeader .knHeader__logo .knHeader__logo-image {
-    width: 100% !important;
-    object-fit: contain !important;
+}
+
+@media (min-width: 768px) and (max-width: 1023px) {
+  .knHeader__logo.knHeader__logo--custom {
+    width: 80% !important; /* Medium width on medium screens */
+    max-width: 800px !important;
   }
-  
-  /* Media queries for larger screens */
-  @media (min-width: 768px) {
-    .knHeader__logo.knHeader__logo--custom {
-      width: 80% !important;
-    }
-  }
-  
-  @media (min-width: 1024px) {
-    .knHeader__logo.knHeader__logo--custom {
-      width: 80% !important; /* Medium width on large screens */
-      max-width: 1000px !important;
-    }
-  }
-  
-  /* Media queries for image resizing */
-  @media (max-width: 767px) {
-    .knHeader__logo.knHeader__logo--custom {
-      width: 100% !important; /* Full width on small screens */
-      max-width: 600px !important;
-    }
-  }
-  
-  @media (min-width: 768px) and (max-width: 1023px) {
-    .knHeader__logo.knHeader__logo--custom {
-      width: 80% !important; /* Medium width on medium screens */
-      max-width: 800px !important;
-    }
-  }
+}

--- a/code/office-city-engineer/oce.css
+++ b/code/office-city-engineer/oce.css
@@ -71,7 +71,7 @@
     border-color: transparent;
     border-radius: 4px;
     box-shadow: 0px 0px 0px 0px gray;
-    background-color: #EB4133;
+    background-color: #E41A1C;
     color: #FFFFFF;
     padding: 1px 10px;
     text-align: center;

--- a/code/office-city-engineer/oce.css
+++ b/code/office-city-engineer/oce.css
@@ -67,9 +67,8 @@
   /***************************************/
   /* Delete Button styling */
   .trigger-button-delete {
-    border-style: solid;
     border-width: 1px;
-    border-color: #EB4133;
+    border-color: transparent;
     border-radius: 4px;
     box-shadow: 0px 0px 0px 0px gray;
     background-color: #EB4133;
@@ -82,7 +81,6 @@
   .trigger-button-delete:hover {
     cursor: pointer;
     opacity: 0.9;
-    filter: brightness(95%);
   }
   
   /*********************************************/


### PR DESCRIPTION
Gitbook Documentation:https://atd-dts.gitbook.io/atd-knack-operations/knack-code/looks/trigger-buttons
Github Issue: https://github.com/cityofaustin/atd-data-tech/issues/21441
> Table: "Manage Concrete Plants” table
> Add delete button to top right of Edit Plant Form

GIF of expected behavior
![790C38F6-5787-4FC3-92D5-0661EC7980B1](https://github.com/user-attachments/assets/88a21b1e-4b5a-4b66-bf9c-b08546e9bbf2)
 
# Review
- I made the button red to match the standard web design of delete buttons as red. The red color is `#E41A1C` from the style guide on status colors on our gitbook. If you have any thoughts on an official red color to use for delete buttons that would make more sense
- The button is thinner than most of our other buttons. I thought it would make sense as it is a delete button instead of our other buttons. Also it being on a modal form would contribute to the scroll length of the form
- I had to do a couple commits because of an indentation issue I caught last minute (with my IDE not on Knack). Also changing the red color.