### PR TITLE
Fix dropdown menu on click for Operating Authority form

### DIFF
--- a/code/mobility-services/mobility-services.js
+++ b/code/mobility-services/mobility-services.js
@@ -231,7 +231,7 @@ function dropdownMenuItem(recordId, route, linkName) {
 // Dictionary of views needing dropdown menu in editable Operating Authority (OA) pages
 var viewNameOA = {
   687: "1 - Service Type",
-  676: "2 - Business Information",
+  750: "2 - Business Information",
   689: "3 - Insurance",
   691: "4 - Authorized Person",
   693: "5 - Vehicle Information",
@@ -251,12 +251,12 @@ for (let key in viewNameOA) {
         <li class="desktop-dropdown-menu kn-dropdown-menu kn-button">\
         <a><span class="nav-dropdown-link">${currentMenu}</span>\
           <span class="kn-dropdown-icon fa fa-caret-down" /></a>\
-          <a href="#application-operating-authority/business-information/${recordId}/business-information/${recordId}" data-kn-slug="#application-operating-authority">\
+          <a href="#application-operating-authority/service-type/${recordId}/service-type/${recordId}" data-kn-slug="#application-operating-authority">\
           </a>\
           <ul class="kn-dropdown-menu-list desktop-dropdown-menu-list" style="min-width: 152px; margin: 0;">\
             ${dropdownMenuItem(
               recordId,
-              "application-operating-authority-service-type",
+              "service-type",
               "1 - Service Type"
             )}\
             ${dropdownMenuItem(
@@ -272,7 +272,7 @@ for (let key in viewNameOA) {
             )}\
             ${dropdownMenuItem(
               recordId,
-              "application-operating-authority-vehicles",
+              "vehicle-information",
               "5 - Vehicle Information"
             )}\
             ${dropdownMenuItem(
@@ -290,7 +290,7 @@ for (let key in viewNameOA) {
         <ul class="desktop-dropdown-menu-list" style="min-width: 152px; margin: .5em;">\
           ${dropdownMenuItem(
             recordId,
-            "application-operating-authority-service-type",
+            "service-type",
             "1 - Service Type"
           )}\
             ${dropdownMenuItem(
@@ -306,7 +306,7 @@ for (let key in viewNameOA) {
             )}\
             ${dropdownMenuItem(
               recordId,
-              "application-operating-authority-vehicles",
+              "vehicle-information",
               "5 - Vehicle Information"
             )}\
             ${dropdownMenuItem(

--- a/code/mobility-services/mobility-services.js
+++ b/code/mobility-services/mobility-services.js
@@ -277,7 +277,7 @@ for (let key in viewNameOA) {
             )}\
             ${dropdownMenuItem(
               recordId,
-              "application-operating-authority-details",
+              "review-and-submit",
               "6 - Review and Submit"
             )}\
           </ul>\
@@ -311,7 +311,7 @@ for (let key in viewNameOA) {
             )}\
             ${dropdownMenuItem(
               recordId,
-              "application-operating-authority-details",
+              "review-and-submit",
               "6 - Review and Submit"
             )}\
       </li>\

--- a/code/mobility-services/mobility-services.js
+++ b/code/mobility-services/mobility-services.js
@@ -249,9 +249,9 @@ for (let key in viewNameOA) {
       $(`<div class="details-dropdown-menu tabs">\
       <ul id="desktop-menu-list">\
         <li class="desktop-dropdown-menu kn-dropdown-menu kn-button">\
+        <a><span class="nav-dropdown-link">${currentMenu}</span>\
+          <span class="kn-dropdown-icon fa fa-caret-down" /></a>\
           <a href="#application-operating-authority/business-information/${recordId}/business-information/${recordId}" data-kn-slug="#application-operating-authority">\
-            <span class="nav-dropdown-link">${currentMenu}</span>\
-            <span class="kn-dropdown-icon fa fa-caret-down" />\
           </a>\
           <ul class="kn-dropdown-menu-list desktop-dropdown-menu-list" style="min-width: 152px; margin: 0;">\
             ${dropdownMenuItem(


### PR DESCRIPTION
Details are at: https://github.com/cityofaustin/atd-data-tech/issues/22247
Gitbook documentation of original code: https://atd-dts.gitbook.io/atd-knack-operations/knack-code/looks/dropdown-menu-buttons

This is a fix to a dropdown menu that exists in Operating Authority form in the app currently.

# Old
Tap or click on button will redirect to to current page. This is fine on desktop since mouse can hover to show the dropdown menu, **but not good for touch screen devices since it will make it almost impossible to navigate through the pages of the form**.
<img src="https://private-user-images.githubusercontent.com/31259724/436715058-a13db21a-98da-42f0-a7e5-c994d5b5300c.GIF?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NDU0Mzk1ODIsIm5iZiI6MTc0NTQzOTI4MiwicGF0aCI6Ii8zMTI1OTcyNC80MzY3MTUwNTgtYTEzZGIyMWEtOThkYS00MmYwLWE3ZTUtYzk5NGQ1YjUzMDBjLkdJRj9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTA0MjMlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUwNDIzVDIwMTQ0MlomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTVhZDliNWQ5NzBlZDFlNzY0ZGM3ZWJkMDNmNThjNzgyOTE4ZWJjNzQ1N2MxNGEyODdiMjMwOWQ1NzFkMDFiMDgmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.6TzIydLIAi3lgr5XfQ579xrBzBs2QAfcO3YtCO4fE30" alt="old" width="500"/>

# New
Tap or click on button will now just show the dropdown menu. Gives user's with touch screens the ability to navigate to different pages of the form.
<img src="https://private-user-images.githubusercontent.com/31259724/436717403-559a4e3c-bbfb-4809-9cb6-7183da5228f4.GIF?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NDU0Mzk1ODIsIm5iZiI6MTc0NTQzOTI4MiwicGF0aCI6Ii8zMTI1OTcyNC80MzY3MTc0MDMtNTU5YTRlM2MtYmJmYi00ODA5LTljYjYtNzE4M2RhNTIyOGY0LkdJRj9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTA0MjMlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUwNDIzVDIwMTQ0MlomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWFkOGJiNGNmZDM5MThiZDY1OWRlMjZhYjA1ODEyZGU5NmY0NzMwZDExYWFiMjEzMDY1ZTU0YmYxMzhmNGI5OGMmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.iPISd4tmBlbTNKumGeDBbWPt3CZXUgyvmGZ7z-osIa4" alt="new" width="500"/>
I moved this snippet to before the `<a href>` which disabled it from becoming a link, but it removed the text padding so I added an `<a></a>` tag but it also lead to a cosmetic gap.
```
<span class="nav-dropdown-link">${currentMenu}</span>\
<span class="kn-dropdown-icon fa fa-caret-down" />
```
![image](https://github.com/user-attachments/assets/b81bcd15-a93c-4ef5-9e33-6341c7dc2d86)
