### PR TITLE
Operating Authority: Meaningful Link Names for Viewing Attachments

### DIFF
--- a/code/mobility-services/mobility-services.js
+++ b/code/mobility-services/mobility-services.js
@@ -1,3 +1,4 @@
+const APP_URL = `https://atd.knack.com/${Knack.app.attributes.slug}`;
 /********************************************/
 /*************** Big Buttons ****************/
 /********************************************/
@@ -11,31 +12,31 @@ function bigButton(id, view_id, url, fa_icon, button_label, target_blank = false
 	//>>>HOME TAB BUTTONS
 $(document).on('knack-view-render.view_11', function(event, page) {
   // create large AVAILABLE SERVICES button on the PORTAL page
-    bigButton('available-services', 'view_11', "https://atd.knack.com/mobility-services#available-services/", "list-ul", "Available Services");
+  bigButton('available-services', 'view_11', `${APP_URL}#available-services/`, "list-ul", "Available Services");
 });
 $(document).on('knack-view-render.view_16', function(event, page) {
   // create large CUSTOMER PORTAL button on the PORTAL page
-    bigButton('available-services', 'view_16', "https://atd.knack.com/mobility-services#portal/", "child", "Customer Portal");
+  bigButton('available-services', 'view_16', `${APP_URL}#portal/`, "child", "Customer Portal");
 });
 $(document).on('knack-view-render.view_34', function(event, page) {
   // create large REQUIRED DOCUMENTS button on the CHAUFFEUR page
-    bigButton('required-documents-chauffeur', 'view_34', "https://atd.knack.com/mobility-services#chauffeur-permit/required-documents-chauffeur/", "files-o", "Required Documents");
+  bigButton('required-documents-chauffeur', 'view_34', `${APP_URL}#chauffeur-permit/required-documents-chauffeur/`, "files-o", "Required Documents");
 });
 $(document).on('knack-view-render.view_36', function(event, page) {
   // create large START APPLICATION button on the CHAUFFEUR page
-    bigButton('start-application', 'view_36', "https://atd.knack.com/mobility-services#application-chauffeur/", "arrow-right", "Start Chauffeur Application");
+  bigButton('start-application', 'view_36', `${APP_URL}#application-chauffeur/`, "arrow-right", "Start Chauffeur Application");
 });
 $(document).on('knack-view-render.view_41', function(event, page) {
   // create large SIGN UP or Log-In button on the PORTAL page
-    bigButton('sign-up', 'view_41', "https://atd.knack.com/mobility-services#sign-up", "sign-in", "Sign up or Log In ");
+  bigButton('sign-up', 'view_41', `${APP_URL}#sign-up`, "sign-in", "Sign up or Log In ");
 });
 $(document).on('knack-view-render.view_57', function(event, page) {
   // create large CUSTOMER PORTAL button on the PORTAL page
-    bigButton('available-services', 'view_57', "https://atd.knack.com/mobility-services#portal/", "arrow-right", "Mobility Services Portal");
+  bigButton('available-services', 'view_57', `${APP_URL}#portal/`, "arrow-right", "Mobility Services Portal");
 });
 $(document).on('knack-view-render.view_383', function(event, page) {
   // create large START APPLICATION button on the Operating Authority page
-    bigButton('start-application', 'view_383', "https://atd.knack.com/mobility-services#application-operating-authority", "arrow-right", "Start Operating Authority Application");
+  bigButton('start-application', 'view_383', `${APP_URL}#application-operating-authority`, "arrow-right", "Start Operating Authority Application");
 });
 
 /***************************************/
@@ -108,10 +109,50 @@ for (let i = 0; i < textBoxFieldIDs.length; i++) {
 }
 
 /********************************************************/
-/** Relabel Attachment Links in Tables to 'Attachment' **/
+/** Relabel Attachment Links in Tables to Name Field **/
 /********************************************************/
+//  replace attachment file name with name field. hide_name to hide nameField from tabl
+function replaceAttachmentFilenameWithNameField(fileFieldId, nameFieldId, hide_name = true) {
+  //  find each attachment cell
+  $("td." + fileFieldId).each(function() {
+    //  find each attachment link within the cell
+    $(this).find("span").children("span").each(function() {
+      var attachmentType = "View";
+      var fileRecordId = $(this).context.id;
+
+      //  if neighboring field exists on same table, retrieve the corresponding type
+      $(this).closest("tr").children("td." + nameFieldId)
+        .find("span")
+        .children("span")
+        .each(function() {
+          var nameRecordId = $(this).context.id;
+          if (fileRecordId == nameRecordId) {
+            attachmentType = $(this).text();
+          }
+        });
+      //  update link contents
+      $(this).find("a").html(attachmentType);
+    });
+
+    // Remove duplicate break lines
+    $('br').each(function () {
+      if ($(this).next().is('br')) {
+        $(this).next().remove();
+      }
+    });
+
+  });
+
+  // hides the name field ID based on third parameter. Default true.
+  if (hide_name){
+    $("td." + nameFieldId).hide();
+    $("th." + nameFieldId).hide();
+  }
+}
+
 $(document).on("knack-view-render.any", function (event, view, data) {
   $("a.kn-view-asset").html("View");
+  replaceAttachmentFilenameWithNameField("field_285", "field_458");
 });
 
 /****************************************************/

--- a/code/mobility-services/mobility-services.js
+++ b/code/mobility-services/mobility-services.js
@@ -12,15 +12,15 @@ function bigButton(id, view_id, url, fa_icon, button_label, target_blank = false
 	//>>>HOME TAB BUTTONS
 $(document).on('knack-view-render.view_11', function(event, page) {
   // create large AVAILABLE SERVICES button on the PORTAL page
-  bigButton('available-services', 'view_11', `${APP_URL}#available-services/`, "list-ul", "Available Services");
+  bigButton('available-services', 'view_11', `${APP_URL}#available-services/`, 'list-ul', 'Available Services');
 });
 $(document).on('knack-view-render.view_16', function(event, page) {
   // create large CUSTOMER PORTAL button on the PORTAL page
-  bigButton('available-services', 'view_16', `${APP_URL}#portal/`, "child", "Customer Portal");
+  bigButton('available-services', 'view_16', `${APP_URL}#portal/`, 'child', 'Customer Portal');
 });
 $(document).on('knack-view-render.view_34', function(event, page) {
   // create large REQUIRED DOCUMENTS button on the CHAUFFEUR page
-  bigButton('required-documents-chauffeur', 'view_34', `${APP_URL}#chauffeur-permit/required-documents-chauffeur/`, "files-o", "Required Documents");
+  bigButton('required-documents-chauffeur', 'view_34', `${APP_URL}#chauffeur-permit/required-documents-chauffeur/`, 'files-o', 'Required Documents');
 });
 $(document).on('knack-view-render.view_36', function(event, page) {
   // create large START APPLICATION button on the CHAUFFEUR page
@@ -28,15 +28,15 @@ $(document).on('knack-view-render.view_36', function(event, page) {
 });
 $(document).on('knack-view-render.view_41', function(event, page) {
   // create large SIGN UP or Log-In button on the PORTAL page
-  bigButton('sign-up', 'view_41', `${APP_URL}#sign-up`, "sign-in", "Sign up or Log In ");
+  bigButton('sign-up', 'view_41', `${APP_URL}#sign-up`, 'sign-in', 'Sign up or Log In');
 });
 $(document).on('knack-view-render.view_57', function(event, page) {
   // create large CUSTOMER PORTAL button on the PORTAL page
-  bigButton('available-services', 'view_57', `${APP_URL}#portal/`, "arrow-right", "Mobility Services Portal");
+  bigButton('available-services', 'view_57', `${APP_URL}#portal/`, 'arrow-right', 'Mobility Services Portal');
 });
 $(document).on('knack-view-render.view_383', function(event, page) {
   // create large START APPLICATION button on the Operating Authority page
-  bigButton('start-application', 'view_383', `${APP_URL}#application-operating-authority`, "arrow-right", "Start Operating Authority Application");
+  bigButton('start-application', 'view_383', `${APP_URL}#application-operating-authority`, 'arrow-right', 'Start Operating Authority Application');
 });
 
 /***************************************/

--- a/code/mobility-services/mobility-services.js
+++ b/code/mobility-services/mobility-services.js
@@ -104,14 +104,14 @@ function showCharacterLimit(view_id, field_id, charLimit) {
 const textBoxFieldIDs = [48, 49, 52, 53, 76, 86, 56]; // lists paragraph fields
 /* Character limit */
 for (let i = 0; i < textBoxFieldIDs.length; i++) {
-  showCharacterLimit("view_83", "field_" + textBoxFieldIDs[i], 500); // background info page view
-  showCharacterLimit("view_155", "field_" + textBoxFieldIDs[i], 500); // edit application page view
+  showCharacterLimit("view_83", "field_" + textBoxFieldIDs[i], 500);  // Background Info page view
+  showCharacterLimit("view_155", "field_" + textBoxFieldIDs[i], 500); // Edit Application page view
 }
 
 /********************************************************/
 /** Relabel Attachment Links in Tables to Name Field **/
 /********************************************************/
-//  replace attachment file name with name field. hide_name to hide nameField from tabl
+//  replace attachment file name with name field. hide_name to hide nameField from table
 function replaceAttachmentFilenameWithNameField(fileFieldId, nameFieldId, hide_name = true) {
   //  find each attachment cell
   $("td." + fileFieldId).each(function() {

--- a/code/mobility-services/mobility-services.js
+++ b/code/mobility-services/mobility-services.js
@@ -117,15 +117,15 @@ function replaceAttachmentFilenameWithNameField(fileFieldId, nameFieldId, hide_n
   $("td." + fileFieldId).each(function() {
     //  find each attachment link within the cell
     $(this).find("span").children("span").each(function() {
-      var attachmentType = "View";
-      var fileRecordId = $(this).context.id;
+      let attachmentType = "View";
+      let fileRecordId = $(this).context.id;
 
       //  if neighboring field exists on same table, retrieve the corresponding type
       $(this).closest("tr").children("td." + nameFieldId)
         .find("span")
         .children("span")
         .each(function() {
-          var nameRecordId = $(this).context.id;
+          let nameRecordId = $(this).context.id;
           if (fileRecordId == nameRecordId) {
             attachmentType = $(this).text();
           }


### PR DESCRIPTION
This is for https://github.com/cityofaustin/atd-data-tech/issues/23298

## File Name Attachment
The goal is to update the file name to the corresponding field `Display Short Attachment Type` on instead of the default `View`. For parent record such as vehicles or additional people, this meant having possibly 3-8 attachments per record depending on the service type selection.

<img width="801" height="113" alt="image" src="https://github.com/user-attachments/assets/57f638e8-1a32-4e0a-b29d-3065e74cb4e8" />


<img width="624" height="336" alt="image" src="https://github.com/user-attachments/assets/9a86cf4e-2d46-47fc-ba45-63d4c09fb3ba" />

### Important considerations
- Similar to the Signs and Markings application, the `Display Short Attachment Type` field column has to be on the table view for the code to work. Otherwise, it will default to the "View" on the table. Since the field is only used to display a shortened version of the file, this will not conflict with any other permit applications such as Chauffeur or future applications.
- This will only work for Table views currently. It uses the formatting of the table's HTML such as `span id` to determine the name of the file attachment. 
- This works from a parent -> connected record table view
   - Example: 
      - Vehicle record -> Many attachment
      - Additional People record -> Many attachments
- Since the Operating Authority application works by pre-populating the attachment record, the `File(s) Attached` table header would have `<br>` on missing files. Lines 137-142 removes redundant break line
- line 147-150 is used to hide the column `Display Short Attachment Type` in the table itself. I use a parameter currently that hides it in the function.

## APP Url for Big Buttons
Unrelated to issue above I added a constant `APP_URL` in line 1 so the big buttons would be useable in a Test environment for line 1-39. 
This means whenever copying the MSP app moving forward, certain big buttons using the `APP_URL` constant in a test app would redirect to the test environment instead of always the production app which is annoying when working in test apps. This does not change anything in production.