### PR TITLE
Test AMD Data Tracker with Multiple Attachments - Flag that not all records created if on bad connection

### DIFF
--- a/code/test-data-tracker/test-data-tracker.css
+++ b/code/test-data-tracker/test-data-tracker.css
@@ -336,3 +336,12 @@ img.knHeader__logo-image {
     max-width: 800px !important;
   }
 }
+
+/*********************************************/
+/******** Add Multiple Attachments  ********/
+/*********************************************/
+#dropzone-field_4212 {
+  border: 2px dashed #A8B2BC;
+  border-radius: 5%;
+  font-weight: 500;
+}


### PR DESCRIPTION
For Discovery Day, I explored implements custom JS that will allow a user to attach multiple files per form submit in Knack. I made a slide deck [here](https://docs.google.com/presentation/d/1JVGQPIFtLXIBfCsmstHKX7iAptP--NJESFwA0zj00ww/edit?usp=sharing). Related to https://github.com/cityofaustin/atd-data-tech/issues/22796

The JavaScript library used is [dropzone.js](https://www.dropzone.dev/)
- Documentation: https://docs.dropzone.dev/

This is a modification from this code: https://github.com/hamiltont/knack-extensions/blob/master/dropzone-bridge.js

A [24 second video](https://drive.google.com/file/d/1yk5D2KfxWOqj3zt15clMewtuiDgf6CH7/view?usp=sharing) demo of the code in action in AMD Data Tracker Test on desktop with ethernet.

# The Problem
Currently, it works as expected when adding multiple attachments as long as the device is on a reliable internet connection. However, since most of the users submitting attachments are doing it on the field, there is a possibility that the internet/hotspot connection is slow/unreliable.

If on a slow internet connection such as Cameron Rd office WiFi or in the field, there is a high risk that not all records are created as expected. For example when a user attaches 10 photos, Knack might accept 1-3 photos instead of 10 as expected.

We want the user to be flagged that not all records were created. However currently the code does not visually show that not all records are created and is instead the pop-up visually shows that all files were uploaded, but not all records created from the ajax call.

## Specifications
```
**********************************/
/*** Add multiple attachments ***/
/********************************/
const KNACK_APP_ID = Knack.application_id;
var fieldId = 'field_4212';
var viewId = 'view_4214';
var sceneId = 'scene_1688';
var maxFilesLoaded = 10; // Maximum amount of files uploaded in dropzone
```

## Testing
1. Go to https://atd.knack.com/test--austin-transportation-data-tracker--23-may-2025#work-orders-inspectors/edit-work-order4/6830a8569501c102e6a20450/
2. Sign in with Non-SSO since this is a test app (AMD Test User is in 1PW)
3. Scroll to click on **Add Attachment (Dz)** button
4. For desktop Chrome: Right click > Inspect > Throttle to low-tier mobile
5. Add multiple files from devices
6. Result: Either all files are attached or only some of them.
<img width="1920" height="911" alt="image" src="https://github.com/user-attachments/assets/2c35a35b-a803-4014-8f13-9122da6b4fe1" />

## Criteria
- Better messaging when uploads are failing
- Addressing any obvious issues in the code that could be causing the load failure