### PR TITLE
Urban Forestry - Wrap table headers on advance search

### DIFF
--- a/code/urban-forestry/urban-forestry.css
+++ b/code/urban-forestry/urban-forestry.css
@@ -86,13 +86,6 @@ a.small-button {
   text-decoration: none;
 }
 
-/*******************************************/
-/************ Wrap Table Headers ***********/
-/*******************************************/
-#view_133 th, #view_147 th {
-  white-space:normal;
-}
-
 /*********************************************/
 /******** Header Banner Image Styling ********/
 /*********************************************/
@@ -151,4 +144,11 @@ img.knHeader__logo-image {
     width: 80% !important; /* Medium width on medium screens */
     max-width: 800px !important;
   }
+}
+
+/*******************************************/
+/************ Wrap Table Headers ***********/
+/*******************************************/
+#view_133 th, #view_147 th {
+  white-space:normal;
 }

--- a/code/urban-forestry/urban-forestry.css
+++ b/code/urban-forestry/urban-forestry.css
@@ -75,7 +75,7 @@ a.big-button-container {
 .small-button-container:hover {
   background-color: #4c4c4c;
   cursor: pointer;
-//}
+}
 
 .small-button-disabled {
   background-color: #f7f7f7;
@@ -86,150 +86,11 @@ a.small-button {
   text-decoration: none;
 }
 
-/*********************************************/
-/******** Header Banner Image Styling ********/
-/*********************************************/
-
-/* Base styles for the image */
-img.knHeader__logo-image {
-  width: 100% !important;
-  height: auto !important;
-  max-width: 100% !important;
-  object-fit: contain !important;
-}
-
-/* Base styles for the parent container */
-.knHeader__logo.knHeader__logo--custom {
-  height: auto !important;
-  max-width: 1000px !important;
-  margin: 0 0 0 0 !important; /* Left-justified */
-}
-
-/* Overrides for conflicting styles */
-.knHeader .knHeader__logo--custom {
-  width: 100% !important;
-  max-width: 1000px !important;
-  margin: 0 0 0 0 !important; /* Left-justified */
-}
-
-.knHeader .knHeader__logo .knHeader__logo-image {
-  width: 100% !important;
-  object-fit: contain !important;
-}
-
-/* Media queries for larger screens */
-@media (min-width: 768px) {
-  .knHeader__logo.knHeader__logo--custom {
-    width: 80% !important;
-  }
-}
-
-@media (min-width: 1024px) {
-  .knHeader__logo.knHeader__logo--custom {
-    width: 80% !important; /* Medium width on large screens */
-    max-width: 1000px !important;
-  }
-}
-
-/* Media queries for image resizing */
-@media (max-width: 767px) {
-  .knHeader__logo.knHeader__logo--custom {
-    width: 100% !important; /* Full width on small screens */
-    max-width: 600px !important;
-  }
-}
-
-@media (min-width: 768px) and (max-width: 1023px) {
-  .knHeader__logo.knHeader__logo--custom {
-    width: 80% !important; /* Medium width on medium screens */
-    max-width: 800px !important;
-  }
-}/**************************************/
-/***** Validation Message Styling *****/
-/**************************************/
-.kn-notification, .is-confirmation, .is-warning, .is-alert { font-size: 1.25em !important; color: black !important;}
-.kn-notification { background-color: #2acee3 !important;}
-.is-confirmation { background-color: #caf4bc !important;}
-.is-warning { background-color: #ffe09a !important;}
-.is-alert { background-color: #ff9b9c !important;}
-
-/***************************************/
-/********* FA Icon Positioning *********/
-/***************************************/
-/*Centers icon vertically on a line*/
-.fa { vertical-align: baseline; }
-/*Icon rests at the bottom of a line*/
-.fa-bot { vertical-align: text-bottom; }
-/*Icon touches the top of a line*/
-.fa-top { vertical-align: text-top; }
-
-/****************************************/
-/************ Button Effects ************/
-/****************************************/
-/*Call this class anytime you want to use this cursor*/
-.disabled { cursor: not-allowed; }
-
-/*Call this class anytime you want to center button text*/
-.centered-text { text-align: center; }
-
-/*Close Modal 'X' Button*/
-.delete { border: #adb5bd .2em !important; background-color: #adb5bd !important;}
-.close-modal {border: #495057 !important; background-color: #495057 !important;}
-.delete:before, .delete:after { background-color: white !important; width: 66% !important; left: 42% !important; height: 3px !important; border-radius: 2px !important;}
-
-/***************************************/
-/************* Big Buttons *************/
-/***************************************/
-.big-button-container {
-  padding: 20px 20px;
-  border-radius: 4px;
-  box-shadow: 0px 1px 2px 0px gray;
-  font-size: 2.5em;
-  max-width: 14em;
-  display: block;
-}
- 
-.big-button-container:hover {
-  background-color: #f7f7f7;
-  cursor: pointer;
-}
-
-.big-button-disabled {
-  background-color: #f7f7f7;
-  opacity: 0.6;
-  pointer-events: none;
-}
- 
-a.big-button-container { 
-  text-decoration: none;
-}
-
-/***************************************/
-/************ Small Buttons ************/
-/***************************************/
-.small-button-container {
-  padding: 5px 10px;
-  margin: 10px;
-  border-radius: 4px;
-  box-shadow: 0px 1px 2px 0px gray;
-  font-size: 1em;
-  max-width: 15em;
-  background-color: #babbbc;
-  color: white;
-}
-
-.small-button-container:hover {
-  background-color: #4c4c4c;
-  cursor: pointer;
-//}
-
-.small-button-disabled {
-  background-color: #f7f7f7;
-  opacity: 0.6;
-}
-
-a.small-button {
-  text-decoration: none;
+/*******************************************/
+/************ Wrap Table Headers ***********/
+/*******************************************/
+#view_133 th, #view_147 th {
+  white-space:normal;
 }
 
 /*********************************************/


### PR DESCRIPTION
Added wrap table header property to Advance Search `view_133` and `view_147` for column header text using the `<th>`

Also removed the comment slashes `//` on line 78 as I am assuming it was a typo(?).

This is for https://github.com/cityofaustin/atd-data-tech/issues/23780

Christina and I tested the Export button as a CSV functionality.  We found that column header text is not affected by this change as it is from the CSS instead of the HTML.

## New CSS
```
/*******************************************/
/************ Wrap Table Headers ***********/
/*******************************************/
#view_133 th, #view_147 th {
  white-space:normal;
}
```
## No CSS / Default
On laptop screens user will have to horizontal scroll to see all columns.
<img width="590" alt="image" src="https://github.com/user-attachments/assets/df6fe4df-2168-4f8c-aa70-eab17fa7fa7a"  />

## With CSS
On laptop screens user see all columns. Table Header text wraps max is 5 lines with horizontal scroll.
<img width="590"  alt="image" src="https://github.com/user-attachments/assets/d0168b31-908a-4cf7-bc18-e6375c78d398" />