### PR TITLE
Removed trailing breadcrumbs and back links in Operating Authority

### DIFF
--- a/code/mobility-services/mobility-services.css
+++ b/code/mobility-services/mobility-services.css
@@ -217,7 +217,6 @@ a.trigger-button-large {
 }
 
 /***************************************/
-/***************************************/
 /************* Big Buttons *************/
 /***************************************/
 .big-button-container {
@@ -244,10 +243,32 @@ a.big-button-container {
   text-decoration: none;
 }
 
-/****************************************/
-/************ Button Effects ************/
-/****************************************/
-/* .disabled { cursor: not-allowed; } // disabled for visual bug in big trigger button */
+/**************************************/
+/***** Validation Message Styling *****/
+/**************************************/
+.kn-notification, .is-confirmation, .is-warning, .is-alert { 
+  color: black !important;
+}
+
+.kn-notification  { background-color: #c0f1f7 !important; }
+.is-confirmation  { background-color: #caf4bc !important; }
+.is-warning       { background-color: #ffe09a !important; }
+.is-alert         { background-color: #ff9b9c !important; }
+
+/**************************************/
+/***** Remove Back Links on Scene *****/
+/**************************************/
+#kn-scene_198 .kn-back-link,    /* Submitted OA            */
+#kn-scene_209 .kn-back-link,    /* 1 - Service Type        */
+#kn-scene_235 .kn-back-link,    /* 2 - Business Info       */
+#kn-scene_239 .kn-back-link,    /* 3 - Insurance           */
+#kn-scene_241 .kn-back-link,    /* 4 - Additional People   */
+#kn-scene_245 .kn-back-link,    /* 5 - Vehicle Information */
+#kn-scene_250 .kn-back-link,    /* 6 - Review and Submit   */
+#kn-scene_288 .kn-back-link     /* 7 - Add Notary          */
+{
+  display: none;
+}
 
 /***************************************/
 /********* FA Icon Positioning *********/
@@ -294,6 +315,7 @@ a.small-button {
     display: none;
   }
 }
+
 
 /* hide knack menu buttons if on desktop */
 @media (min-width: 770px) {
@@ -480,7 +502,8 @@ a.small-button {
   display: none;
 }
 @media print {
-  #view_614 {
+  #view_846,
+  #view_920 {
     display: none;
   }
   #view_640,

--- a/code/mobility-services/mobility-services.js
+++ b/code/mobility-services/mobility-services.js
@@ -338,3 +338,32 @@ $(document).on('knack-record-delete.view_874', function (event, view, data) {
   refreshView('view_876'); // Other Affidavit table
   refreshView('view_464'); // Additional People table in case holder is also a driver
 });
+
+/*******************************************/
+/*** Disable Breadcrumb Navigation Links ***/
+/*******************************************/
+function disableBreadCrumbsNonAdmin() {
+  if (!Knack.user.session) {
+    $(".kn-crumbtrail a").each(function () {
+      $(this).replaceWith($(this).text());
+    });
+  }
+}
+
+let sceneIdDisable = [
+  198,  // Submitted Operating Authority
+  209,  // 1 - Service Type
+  235,  // 2 - Business Information
+  239,  // 3 - Insurance
+  241,  // 4 - Addtional People
+  245,  // 5 - Vehicle Information
+  250,  // 6 - Review and Submit
+  288   // 7 - Add Notary
+];
+
+// Pages to disable crumbtrail
+for (let s in sceneIdDisable) {
+  $(document).on('knack-scene-render.scene_' + sceneIdDisable[s], function () {
+    disableBreadCrumbsNonAdmin();
+  });
+};


### PR DESCRIPTION
This is for https://github.com/cityofaustin/atd-data-tech/issues/20331

Disable nav doc: https://atd-dts.gitbook.io/atd-knack-operations/knack-code/functionality/disable-nav-links
Remove back link doc: https://atd-dts.gitbook.io/atd-knack-operations/knack-code/functionality/remove-back-link

## Additional changes
- Corrected the `view_ids` of print display for the `7 - Add Notary` page on line 505-506
- Added knack message validation CSS styling for improved readability

<img width="468" height="80" alt="image" src="https://github.com/user-attachments/assets/b7819c7a-f60a-45db-b862-0f61d403fde7" />
<img width="1005" height="75" alt="image" src="https://github.com/user-attachments/assets/067af443-7319-40a7-ae09-f5a7f5fa3608" />
<img width="1672" height="74" alt="image" src="https://github.com/user-attachments/assets/28c20b30-5009-4e6b-9be0-c15e948d4422" />


