### PR TITLE
 COA Footer for any Knack app

### DIFF
--- a/code/common/coa-footer/coa-footer.css
+++ b/code/common/coa-footer/coa-footer.css
@@ -1,3 +1,23 @@
-/***
- * 
- * /
+#coa-footer,
+#coa-footer-modal {
+  text-align: center;
+  padding: 24px 16px;
+  margin-top: 32px;
+  font-size: 13px;
+  color: #888;
+  border-top: 1px solid #e5e5e5;
+}
+
+#coa-footer img,
+#coa-footer-modal img {
+  display: block;
+  margin: 0 auto 12px;
+  max-width: 80px;
+  height: auto;
+}
+
+#coa-footer a,
+#coa-footer-modal a {
+  color: #555;
+  text-decoration: underline;
+}

--- a/code/common/coa-footer/coa-footer.css
+++ b/code/common/coa-footer/coa-footer.css
@@ -1,3 +1,6 @@
+/*************************************/
+/**** COA FOOTER - Simple Version ****/
+/*************************************/
 #coa-footer,
 #coa-footer-modal {
   text-align: center;

--- a/code/common/coa-footer/coa-footer.css
+++ b/code/common/coa-footer/coa-footer.css
@@ -1,8 +1,7 @@
 /*************************************/
 /**** COA FOOTER - Simple Version ****/
 /*************************************/
-#coa-footer,
-#coa-footer-modal {
+#coa-footer {
   text-align: center;
   padding: 24px 16px;
   margin-top: 32px;
@@ -11,16 +10,14 @@
   border-top: 1px solid #e5e5e5;
 }
 
-#coa-footer img,
-#coa-footer-modal img {
+#coa-footer img {
   display: block;
   margin: 0 auto 12px;
   max-width: 80px;
   height: auto;
 }
 
-#coa-footer a,
-#coa-footer-modal a {
+#coa-footer a {
   color: #555;
   text-decoration: underline;
 }

--- a/code/common/coa-footer/coa-footer.js
+++ b/code/common/coa-footer/coa-footer.js
@@ -1,1 +1,92 @@
-// hewwo world
+(function() {
+
+  const footerHashes = [
+    '#customer/',                 // scene_482 customer login
+    '#portal-home/',              // scene_291
+    '#all-services/',             // scene_306 (modal)
+    '#portal-home/all-services/', // scene_306 (modal)
+    '#tcp-traffic-control-plan/', // scene_302
+    '#tcp-conflict-shared/',      // scene_305
+    '#contact-us/',               // scene_179 (modal)
+  ];
+
+  const footerHTML = `
+    <div id="coa-footer">
+      <img 
+        src="https://images.gitbook.com/__img/dpr=2,width=760,onerror=redirect,format=auto,signature=1503205633/https%3A%2F%2Ffiles.gitbook.com%2Fv0%2Fb%2Fgitbook-x-prod.appspot.com%2Fo%2Fspaces%252FCqNGfEc0WO4ar1y6yBB3%252Fuploads%252F94aonme89HIUpHVnpeuK%252FCOA-Logo-Horizontal-Official-RGB.png%3Falt%3Dmedia%26token%3Da9121b5d-9d3c-41d0-9e72-90e25938e553" 
+        alt="City of Austin Footer Logo" 
+      />
+      <a href="https://www.austintexas.gov/page/privacy-policy" target="_blank" rel="noopener noreferrer">
+        Privacy Policy
+      </a>
+    </div>
+  `;
+
+  function isModalOpen() {
+    return $('.kn-modal-bg').is(':visible') || $('.kn-modal').is(':visible');
+  }
+
+  function injectFooter() {
+    // Skip everything if a modal is currently open
+    if (isModalOpen()) return;
+
+    const hash = window.location.hash;
+    const shouldShow = footerHashes.some(function(h) { return hash.startsWith(h); });
+
+    if (shouldShow) {
+      // Only inject if footer is already present inside #knack-body
+      if ($('#knack-body #coa-footer').length) return;
+
+      const maxAttempts = 20;
+      let attempts = 0;
+
+      const interval = setInterval(function() {
+        attempts++;
+        if ($('#knack-body').length) {
+          clearInterval(interval);
+          // Remove any orphaned footer before appending fresh one
+          $('#coa-footer').remove();
+          $('#knack-body').append(footerHTML);
+        } else if (attempts >= maxAttempts) {
+          clearInterval(interval);
+          console.warn('COA Footer: #knack-body not found after max attempts');
+        }
+      }, 100);
+
+    } else {
+      // Navigated away from a footer page, remove it
+      $('#coa-footer').remove();
+    }
+  }
+
+  function injectModalFooter() {
+    const $modalBody = $('.modal-card-body');
+    if (!$modalBody.length) return;
+    // Avoid duplicate
+    if ($modalBody.find('#coa-footer-modal').length) return;
+    // Use a separate ID so it doesn't conflict with the page footer
+    const $modalFooter = $(footerHTML.replace('id="coa-footer"', 'id="coa-footer-modal"'));
+    $modalBody.append($modalFooter);
+  }
+
+  // Watch for modal being added to the DOM
+  const observer = new MutationObserver(function(mutations) {
+    mutations.forEach(function(mutation) {
+      mutation.addedNodes.forEach(function(node) {
+        if ($(node).hasClass('kn-modal') || $(node).find('.kn-modal').length) {
+          // Small delay to let modal content fully render
+          setTimeout(injectModalFooter, 300);
+        }
+      });
+    });
+  });
+
+  observer.observe(document.body, { childList: true, subtree: true });
+
+  // Run on initial load
+  $(window).on('load', injectFooter);
+
+  // Run on every hash change (Knack navigation)
+  $(window).on('hashchange', injectFooter);
+
+})();

--- a/code/common/coa-footer/coa-footer.js
+++ b/code/common/coa-footer/coa-footer.js
@@ -27,39 +27,42 @@
   }
 
   function injectFooter() {
-    // Skip everything if a modal is currently open
+    const hash = window.location.hash;
+    const shouldShow = footerHashes.some(function(h) { return hash === h; });
+
+    // Always remove if we're on a non-footer page
+    if (!shouldShow) {
+      $('#coa-footer').remove();
+      return;
+    }
+
+    // Skip inject if a modal is currently open
     if (isModalOpen()) return;
 
-    const hash = window.location.hash;
-    const shouldShow = footerHashes.some(function(h) { return hash.startsWith(h); });
+    // Only inject if footer is not already present inside #knack-body
+    if ($('#knack-body #coa-footer').length) return;
 
-    if (shouldShow) {
-      // Only inject if footer is already present inside #knack-body
-      if ($('#knack-body #coa-footer').length) return;
+    const maxAttempts = 20;
+    let attempts = 0;
 
-      const maxAttempts = 20;
-      let attempts = 0;
-
-      const interval = setInterval(function() {
-        attempts++;
-        if ($('#knack-body').length) {
-          clearInterval(interval);
-          // Remove any orphaned footer before appending fresh one
-          $('#coa-footer').remove();
-          $('#knack-body').append(footerHTML);
-        } else if (attempts >= maxAttempts) {
-          clearInterval(interval);
-          console.warn('COA Footer: #knack-body not found after max attempts');
-        }
-      }, 100);
-
-    } else {
-      // Navigated away from a footer page, remove it
-      $('#coa-footer').remove();
-    }
+    const interval = setInterval(function() {
+      attempts++;
+      if ($('#knack-body').length) {
+        clearInterval(interval);
+        $('#coa-footer').remove();
+        $('#knack-body').append(footerHTML);
+      } else if (attempts >= maxAttempts) {
+        clearInterval(interval);
+        console.warn('COA Footer: #knack-body not found after max attempts');
+      }
+    }, 100);
   }
 
   function injectModalFooter() {
+    const hash = window.location.hash;
+    const shouldShow = footerHashes.some(function(h) { return hash === h; });
+    if (!shouldShow) return;
+
     const $modalBody = $('.modal-card-body');
     if (!$modalBody.length) return;
     // Avoid duplicate

--- a/code/common/coa-footer/coa-footer.js
+++ b/code/common/coa-footer/coa-footer.js
@@ -1,15 +1,25 @@
+/*************************************/
+/**** COA FOOTER - Simple Version ****/
+/*************************************/
+  // Dynamically injects a branded footer into specific customer-facing standard Knack pages only.
+  // Use this version for apps where displaying the footer on modal windows is not required.
+  // Caution: Navigating from a standard page > modal page > and then to a new standard page from a menu view on that modal page may cause footer ghosting/duplication to occur
+  // Best Practice: Modals are okay as long as a user isnt required to navigate with the modal. Instead the user should navigate via the top nav or a standard page
+  //
+  // To display the footer on a new page: append its URL hash and scene ID comment to the footerHashes array below.
 (function() {
 
+  // List of exact URL hashes that should display the footer. Only exact matches are used — child pages (e.g. #customer/my-projects/) are automatically excluded.
   const footerHashes = [
     '#customer/',                 // scene_482 customer login
     '#portal-home/',              // scene_291
-    '#all-services/',             // scene_306 (modal)
-    '#portal-home/all-services/', // scene_306 (modal)
+    '#all-services/',             // scene_306
     '#tcp-traffic-control-plan/', // scene_302
     '#tcp-conflict-shared/',      // scene_305
-    '#contact-us/',               // scene_179 (modal)
   ];
 
+  // Our structured Footer HTML consisting of the COA Brand, the Privacy Policy, and any app specific Contact Info
+  // Styling is handled in the Knack CSS file via the #coa-footer selector.
   const footerHTML = `
     <div id="coa-footer">
       <img 
@@ -22,26 +32,23 @@
     </div>
   `;
 
-  function isModalOpen() {
-    return $('.kn-modal-bg').is(':visible') || $('.kn-modal').is(':visible');
-  }
-
+  // Inject footer for standard pages. Runs on initial page load and every time the URL hash changes.
   function injectFooter() {
     const hash = window.location.hash;
+
+    // Check if the current hash exactly matches one of our footer pages
     const shouldShow = footerHashes.some(function(h) { return hash === h; });
 
-    // Always remove if we're on a non-footer page
+    // If we're not on a footer page, remove the footer and exit
     if (!shouldShow) {
       $('#coa-footer').remove();
       return;
     }
 
-    // Skip inject if a modal is currently open
-    if (isModalOpen()) return;
-
-    // Only inject if footer is not already present inside #knack-body
+    // Check if the footer is already present in #knack-body
     if ($('#knack-body #coa-footer').length) return;
 
+    // Poll every 100ms for #knack-body to be available in the DOM as it may not exist immediately after hash change. Exits after 2s.
     const maxAttempts = 20;
     let attempts = 0;
 
@@ -49,7 +56,6 @@
       attempts++;
       if ($('#knack-body').length) {
         clearInterval(interval);
-        $('#coa-footer').remove();
         $('#knack-body').append(footerHTML);
       } else if (attempts >= maxAttempts) {
         clearInterval(interval);
@@ -58,38 +64,10 @@
     }, 100);
   }
 
-  function injectModalFooter() {
-    const hash = window.location.hash;
-    const shouldShow = footerHashes.some(function(h) { return hash === h; });
-    if (!shouldShow) return;
-
-    const $modalBody = $('.modal-card-body');
-    if (!$modalBody.length) return;
-    // Avoid duplicate
-    if ($modalBody.find('#coa-footer-modal').length) return;
-    // Use a separate ID so it doesn't conflict with the page footer
-    const $modalFooter = $(footerHTML.replace('id="coa-footer"', 'id="coa-footer-modal"'));
-    $modalBody.append($modalFooter);
-  }
-
-  // Watch for modal being added to the DOM
-  const observer = new MutationObserver(function(mutations) {
-    mutations.forEach(function(mutation) {
-      mutation.addedNodes.forEach(function(node) {
-        if ($(node).hasClass('kn-modal') || $(node).find('.kn-modal').length) {
-          // Small delay to let modal content fully render
-          setTimeout(injectModalFooter, 300);
-        }
-      });
-    });
-  });
-
-  observer.observe(document.body, { childList: true, subtree: true });
-
-  // Run on initial load
+  // Run on initial page load
   $(window).on('load', injectFooter);
 
-  // Run on every hash change (Knack navigation)
+  // Run on every hash change (triggered by navigation)
   $(window).on('hashchange', injectFooter);
 
 })();


### PR DESCRIPTION
This work is to elevate the requirement to post the [City of Austin Privacy Policy](https://www.austintexas.gov/page/privacy-policy) on public facing Knack pages. Instead of manual maintenance, this code provides us an easy way to maintain an array of scenes we would like to target in an app, use standard CSS styling, and have the footer display appropriately on either standard or modal pages. The footer has been centered with the COA branding and a link to the Privacy Policy. The code has been wrapped and uses the image stored on our Knack Media Gitbook. The Footer should appear at the bottom of a page either on load or when the url hash changes.

<img width="267" height="152" alt="image" src="https://github.com/user-attachments/assets/fa4e22f8-9972-408c-8079-dcea1491f6a6" />

This is currently live on the ROW PTE and is a WIP and now available for testing

**05.19.26 Update**
Confirmed with team and went with the simplified approach so now modals are excluded from displaying the footer. Noticed a strange Knack interaction when navigating directly from a modal page to a new standard page causing ghosting/duplication. Converting that page to a standard page fixes the issue at the source. Commenting has been enhanced based on feedback so everyone has a better understanding of what the code is doing and better guidance on how to update it for each app.
