### PR TITLE
ROW Portal: Fix ROW Division Links

### DIFF
--- a/code/right-of-way/right-of-way.js
+++ b/code/right-of-way/right-of-way.js
@@ -123,15 +123,15 @@ $(document).on("knack-view-render.view_1117", function(event, page) {
 });
 // create large ROW Division button on the Customer Portal Home page
 $(document).on("knack-view-render.view_237", function(event, page) {
-  bigButton("row-division-link", "view_237", "https://www.austintexas.gov/transportation-public-works/right-way-row-management", "bank", "ROW Division", true);
+  bigButton("row-division-link", "view_237", "https://www.austintexas.gov/transportation-public-works/divisions/right-way-management", "bank", "ROW Division", true);
 });
 // create large ROW Division button on the ROW Portal page
 $(document).on("knack-view-render.view_684", function(event, page) {
-  bigButton("row-division-link", "view_684", "https://www.austintexas.gov/transportation-public-works/right-way-row-management", "bank", "ROW Division", true);
+  bigButton("row-division-link", "view_684", "https://www.austintexas.gov/transportation-public-works/divisions/right-way-management", "bank", "ROW Division", true);
 });
 // create large ROW Division button on the Customer Home page
 $(document).on("knack-view-render.view_1120", function(event, page) {
-  bigButton("row-division-link", "view_1120", "https://www.austintexas.gov/transportation-public-works/right-way-row-management", "bank", "ROW Division", true);
+  bigButton("row-division-link", "view_1120", "https://www.austintexas.gov/transportation-public-works/divisions/right-way-management", "bank", "ROW Division", true);
 });
 
 // create large Task Board button on the Task Board Login page

--- a/code/right-of-way/right-of-way.js
+++ b/code/right-of-way/right-of-way.js
@@ -123,15 +123,15 @@ $(document).on("knack-view-render.view_1117", function(event, page) {
 });
 // create large ROW Division button on the Customer Portal Home page
 $(document).on("knack-view-render.view_237", function(event, page) {
-  bigButton("row-division-link", "view_237", "https://www.austintexas.gov/department/right-way-row-management", "bank", "ROW Division", true);
+  bigButton("row-division-link", "view_237", "https://www.austintexas.gov/transportation-public-works/right-way-row-management", "bank", "ROW Division", true);
 });
 // create large ROW Division button on the ROW Portal page
 $(document).on("knack-view-render.view_684", function(event, page) {
-  bigButton("row-division-link", "view_684", "https://www.austintexas.gov/department/right-way-row-management", "bank", "ROW Division", true);
+  bigButton("row-division-link", "view_684", "https://www.austintexas.gov/transportation-public-works/right-way-row-management", "bank", "ROW Division", true);
 });
 // create large ROW Division button on the Customer Home page
 $(document).on("knack-view-render.view_1120", function(event, page) {
-  bigButton("row-division-link", "view_1120", "https://www.austintexas.gov/department/right-way-row-management", "bank", "ROW Division", true);
+  bigButton("row-division-link", "view_1120", "https://www.austintexas.gov/transportation-public-works/right-way-row-management", "bank", "ROW Division", true);
 });
 
 // create large Task Board button on the Task Board Login page
@@ -538,3 +538,4 @@ $(document).on("knack-view-render.view_29", function (event, scene) {
   $('input[name$="password"]').val(pw);
   $('input[name$="password_confirmation"]').val(pw);
 });
+


### PR DESCRIPTION
The recent City Site update broke many links. This update fixes the urls so the page does not have to redirect and goes to the new page. Work performed as part of [#27462](https://github.com/cityofaustin/atd-data-tech/issues/27462)

<img width="612" height="127" alt="image" src="https://github.com/user-attachments/assets/53742598-b22b-4638-83df-404218c6408f" />
