### PR TITLE
TDS Portal: Fix TDS Division & SIF Program Links + Accessibility Alt Text for Go To Buttons

### DIFF
--- a/code/transportation-development-services/tds.js
+++ b/code/transportation-development-services/tds.js
@@ -129,11 +129,11 @@ $(document).on("knack-view-render.view_1429", function(event, page) {
 
 // create large TDS Link button on the Customer Portal Home page
 $(document).on("knack-view-render.view_1432", function(event, page) {
-  bigButton("tds-link", "view_1432", "https://www.austintexas.gov/department/transportation-development-services", "bank", "TDS Division Home", true);
+  bigButton("tds-link", "view_1432", "https://www.austintexas.gov/transportation-public-works/divisions/transportation-development-services", "bank", "TDS Division Home", true);
 });
 // create large SIF Link button on the Customer Portal Home page
 $(document).on("knack-view-render.view_1433", function(event, page) {
-  bigButton("sif-program-link", "view_1433", "https://www.austintexas.gov/department/street-impact-fee", "road", "SIF Program", true);
+  bigButton("sif-program-link", "view_1433", "https://www.austintexas.gov/transportation-public-works/programs/street-impact-fee-program", "road", "SIF Program", true);
 });
 
 // create large Task Board button on the Task Board Login page
@@ -1107,12 +1107,12 @@ $(document).on('knack-scene-render.any', function(event, scene) {
   const isModal = Knack.modals.length != 0
   const markup = 
   `
-    <div id="scroll-buttons">
-      <button id="go-to-top" class="kn-button">
-        <i class="fa fa-arrow-up"></i>
+    <div id="scroll-buttons" role="group" aria-label="Quick page navigation">
+      <button id="go-to-top" class="kn-button" aria-label="Go to top of page">
+        <i class="fa fa-arrow-up" aria-hidden="true"></i>
       </button>
-      <button id="go-to-bottom" class="kn-button">
-        <i class="fa fa-arrow-down"></i>
+      <button id="go-to-bottom" class="kn-button" aria-label="Go to bottom of page">
+        <i class="fa fa-arrow-down" aria-hidden="true"></i>
       </button>
     </div>
   `


### PR DESCRIPTION
The recent City Site update broke many links. This update fixes the urls so the page does not have to redirect and goes to the new pages. Work performed as part of [#27461](https://github.com/cityofaustin/atd-data-tech/issues/27461). Additionally this PR includes an alt text update for the Accessibility update [#27291](https://github.com/cityofaustin/atd-data-tech/issues/27291)

<img width="652" height="191" alt="image" src="https://github.com/user-attachments/assets/38ffbf05-e446-4684-ba2a-59342aaa412c" />
<img width="670" height="133" alt="image" src="https://github.com/user-attachments/assets/509f6e78-7b15-4053-bb10-a3d910bb765f" />

Alt Text for these Go To Top/Bottom viewport buttons
<img width="67" height="97" alt="image" src="https://github.com/user-attachments/assets/3a2eec96-89c4-48a6-908b-6de5c50e45f1" />
