### PR TITLE
Urban Forestry: App URL, Big Button, Disable Back Links, and Hide Breadcrumbs Update

### DIFF
--- a/code/urban-forestry/urban-forestry.css
+++ b/code/urban-forestry/urban-forestry.css
@@ -146,6 +146,18 @@ img.knHeader__logo-image {
   }
 }
 
+/**************************************************/
+/** Remove Back Links for Urban Forestry Request **/
+/**************************************************/
+/*Add Images Page*/
+#kn-scene_113 .kn-back-link {
+  display: none;
+}
+/*Request Confirmation Page*/
+#kn-scene_133 .kn-back-link {
+  display: none;
+}
+
 /*******************************************/
 /************ Wrap Table Headers ***********/
 /*******************************************/

--- a/code/urban-forestry/urban-forestry.js
+++ b/code/urban-forestry/urban-forestry.js
@@ -1,3 +1,6 @@
+// Setting constant variable to this app URL
+const APP_URL = `https://atd.knack.com/${Knack.app.attributes.slug}`;
+
 /********************************************/
 /******** COACD Single Sign On Login ********/
 /********************************************/
@@ -44,6 +47,7 @@ $(document).on("knack-view-render.any", function (event, page) {
   if ($ssoButton.length && !$coacdLoginDiv.length) {
     var $ssoView = $ssoButton.closest("[id^=view_]");
     var viewId = $ssoView.get(0).id;
+
     customizeLoginButton(viewId);
   }
 });
@@ -51,28 +55,59 @@ $(document).on("knack-view-render.any", function (event, page) {
 /********************************************/
 /*************** Big Buttons ****************/
 /********************************************/
+// Adds big button HTML directly on View id
 function bigButton(id, view_id, url, fa_icon, button_label, target_blank = false, is_disabled = false, callback = null) {
-  var disabledClass = is_disabled ? " big-button-disabled'" : "'";
-  var newTab = target_blank ? " target='_blank'" : "" ;
-    $( "<a id='" + id + "' class='big-button-container" + disabledClass + " href='" + url + "'"
-      + newTab + "'><span><i class='fa fa-" + fa_icon + "'></i></span><span> " + button_label + "</span></a>" ).appendTo("#" + view_id);
+  const disabledClass = is_disabled ? " big-button-disabled'" : "'";
+  const newTab = target_blank ? " target='_blank'" : "" ;
+  const html = `
+    <a id='${id}' 
+       class='big-button-container${disabledClass}' 
+       href='${url}'${newTab}>
+      <span><i class='fa fa-${fa_icon}'></i></span>
+      <span> ${button_label}</span>
+    </a>
+  `;
+
+  $(`#${view_id}`).append(html);
   if (callback) callback();
 }
 
 // create large Add New MANAGE WORK TICKETS button on the Home page
 $(document).on("knack-view-render.view_113", function(event, page) {
-    bigButton("contractor-work-orders", "view_113", "https://atd.knack.com/urban-forestry#contractor-work-tickets/", "wrench", "Manage Work Tickets");
+    bigButton("contractor-work-orders", "view_113", `${APP_URL}#contractor-work-tickets/`, "wrench", "Manage Work Tickets");
 });
 
 // create large Add New MY WORK TICKETS button on the Home page
 $(document).on("knack-view-render.view_119", function(event, page) {
-  bigButton("my-work-tickets", "view_119", "https://atd.knack.com/urban-forestry#my-work-tickets/", "files-o", "My Work Tickets");
+  bigButton("my-work-tickets", "view_119", `${APP_URL}#created-tickets`, "files-o", "My Work Tickets");
 });
 
 // create large Add New MANAGE ACCOUNTS button on the Home page
 $(document).on("knack-view-render.view_120", function(event, page) {
-  bigButton("manage-resources", "view_120", "https://atd.knack.com/urban-forestry#manage-accounts/", "user", "Manage Resources");
+  bigButton("manage-resources", "view_120", `${APP_URL}#manage-accounts/`, "user", "Manage Resources");
 });
+
+/****************************************************/
+/*** Disable Breadcrumb Navigation Links Function ***/
+/****************************************************/
+function disableBreadcrumbLinks() {
+  if (!Knack.user.session) {
+    $(".kn-crumbtrail a").each(function () {
+      $(this).replaceWith($(this).text());
+    });
+  }
+}
+
+const BREADCRUMB_SCENES = [
+  // Urban Forestry Request
+  'scene_113', // Add Images page
+  'scene_133', // Request Confirmation page
+];
+
+BREADCRUMB_SCENES.forEach(scene => {
+  $(document).on(`knack-scene-render.${scene}`, disableBreadcrumbLinks);
+});
+
 /*******************************/
 /* Generates a Random Password */
 /*******************************/


### PR DESCRIPTION
Implementation of modern App URL and Big Button code per [#24411](https://github.com/cityofaustin/atd-data-tech/issues/24411)

Addition of standard Back Link disabling and modern Breadcrumb hiding for Urban Forestry Request per [#27711](https://github.com/cityofaustin/atd-data-tech/issues/27711)
<img width="727" height="802" alt="image" src="https://github.com/user-attachments/assets/efe96f44-1555-4827-9eb0-f3b77520ad90" />
