### PR TITLE
Knack Classic Accessibility Code snippet

### DIFF
--- a/code/common/accessibility/acccessibility.js
+++ b/code/common/accessibility/acccessibility.js
@@ -1,0 +1,99 @@
+/*******************************/
+/**** Accessibility Updates ****/
+/*******************************/
+// Page Zoom - Global and Mobile layout label
+$(document).on('knack-scene-render.any', function () {
+  const viewport = document.querySelector('meta[name="viewport"]');
+  const mobileNav = document.querySelector('button.knHeader__mobile-nav-toggle');
+  if (viewport) {
+    viewport.setAttribute('content', 'width=device-width, initial-scale=1.0, maximum-scale=2, user-scalable=yes');
+  }
+  if (mobileNav) {
+    mobileNav.setAttribute('aria-label', 'Page navigation');
+  }
+});
+
+/*** Form Field missing label on inputs ****/
+$(document).on('knack-view-render.any', function (event, view, data) {
+  // Goes through every view and field and checks field input name to add aria-label
+  $(this).context.forms.forEach(form => {
+    form.forEach(input => {
+      if (input.className.includes('input kn-keyword-search')) {
+        input.ariaLabel = 'Keyword Search';
+      } else if (input.className.includes('kn-datetime-input knack-date input control hasDatepicker')) {
+        input.ariaLabel = 'Input Date';
+      } else if (input.className.includes('kn-datetime-input kn-time input control ui-timepicker-input')) {
+        input.ariaLabel = 'Input Time'; 
+      } else if (input.className.includes('operator') || input.className.includes('select') || input.className.includes('default')) {
+        input.ariaLabel = 'Select'; 
+      }
+    });
+  });
+
+  // Adds aria-label to search input for all dropdown fields
+  const searchInputs = document.querySelectorAll('.chzn-search');
+  searchInputs.forEach(item => {
+    if (item.hasChildNodes('input')) {
+      item.querySelector('input').setAttribute('aria-label', 'Search');
+    }
+  });
+
+  // Adds aria-label to all close modal buttons
+  const closeModals = document.querySelectorAll("button.delete.close-modal");
+  closeModals.forEach(item => {
+    item.setAttribute('aria-label', "Close modal");
+  });
+
+
+  // If view is a table will check Per page option exists. If so, adds a aria label for dropdown selection.
+  const limitPage = document.querySelectorAll('select[name="limit"]');
+  const pageSelect = document.querySelectorAll('select[name="page_select"]');
+  limitPage.forEach(item => {
+    if (limitPage && item.hasChildNodes('option')) {
+      if (item) {
+        item.setAttribute('aria-label', "Select per page");
+      }
+    }
+  });
+  pageSelect.forEach(item => {
+    if (pageSelect && item.hasChildNodes('option')) {
+      if (item) {
+        item.setAttribute('aria-label', "Select page number");
+      }
+    }
+  });
+
+  // If table header is empty, add aria-label for sort link
+  $("th").find("a").each(function() {
+    if ($(this).context.className == 'kn-sort level is-compact') {
+      const label = $(this).children("span").text();
+      $(this).context.ariaLabel= ("Sort " + label).trimEnd();
+    }
+  });
+
+  // If search choice has multiple options, add aria-label for close link
+  $("search-choice").find("a").each(function() {
+    if ($(this).context.className =='chzn-choices') {
+      const label = $(this).children("span").text();
+      $(this).context.ariaLabel= ("Close " + label).trimEnd();
+    }
+  });
+
+});
+
+// If a dropdown multi-choice has a new item, add close label to close link
+const observer = new MutationObserver(function(mutations) {
+  mutations.forEach(function(mutation) {
+    mutation.addedNodes.forEach(function(node) {
+      if ($(node).hasClass('search-choice')) {
+        const searchChoice = document.querySelectorAll('.search-choice span');
+        const searchChoiceClose = document.querySelectorAll('a.search-choice-close');
+        searchChoiceClose.forEach((item,index) => {
+          const label = searchChoice[index].innerHTML;
+          item.setAttribute('aria-label', `Remove '${label}'`);
+        });
+      }
+    });
+  });
+});
+observer.observe(document.body, { childList: true, subtree: true });

--- a/code/common/accessibility/acccessibility.js
+++ b/code/common/accessibility/acccessibility.js
@@ -81,10 +81,10 @@ $(document).on('knack-view-render.any', function (event, view, data) {
 
 });
 
-// If a dropdown multi-choice has a new item, add close label to close link
 const observer = new MutationObserver(function(mutations) {
   mutations.forEach(function(mutation) {
     mutation.addedNodes.forEach(function(node) {
+      // If a dropdown multi-choice has a new item, add close label to close link
       if ($(node).hasClass('search-choice')) {
         const searchChoice = document.querySelectorAll('.search-choice span');
         const searchChoiceClose = document.querySelectorAll('a.search-choice-close');
@@ -93,6 +93,9 @@ const observer = new MutationObserver(function(mutations) {
           item.setAttribute('aria-label', `Remove '${label}'`);
         });
       }
+      // If an Address field has "Address Auto-complete" toggled on
+      const streetInput = $('input#street');
+      streetInput.attr("autocomplete", "off");
     });
   });
 });

--- a/code/common/accessibility/accessibility.css
+++ b/code/common/accessibility/accessibility.css
@@ -1,0 +1,7 @@
+/*********************************************/
+/******** Accessibility Updates **************/
+/*********************************************/
+.chzn-container-single .chzn-single span,
+h1.modal-card-title {
+  overflow: visible;
+}


### PR DESCRIPTION
This PR is for https://github.com/cityofaustin/atd-data-tech/issues/27905

[Google Doc](https://docs.google.com/document/d/1yN8Y-Z87pIep_NF9Fse7pZ7FnVK29fpjxX6NeqyVNzw/edit?usp=sharing) explaining about the accessibility issues flagger by SiteImprove.

Can view this code snippet in action on the PTE: https://atd.knack.com/pte#portal-home/
Can view most accessibility issues in my Sandbox as well (with code removed): https://atd.knack.com/sandbox-sg#accessibility-test/

# For Testing Tasks
As reviewing, please login to the ROW PTE:
1. Go to https://atd.knack.com/pte#customer/
2. Sign-In using the 1Password credentials named "PTE Accessibility Tester" (On Knack the name is "PTE DACP Tester")
3. Go though the links listed in the [Google Sheets](https://docs.google.com/spreadsheets/d/1p2jVyAjdp9t1njVm7d1erIdC_kYXnM2cEit9IcyMOPw/edit?usp=sharing)
4. Fill out your name, Date tested, complete the task listed with pass/fail, and note any accessibility issues that you catch or any issues/bugs. Specifically anything that is not vendor-related.
   - Modal pop-ups need to be tested as it opens a modal pop-up, not a full page. It will be listed in the task column what page. 

# Addresses the following
- Page Zoom is Restricted
- Form field missing a label
   - Keyword Search
   - Search views with field inputs
      - is any dropdown menu
      - Date/Time
      - Multi-choice option (dropdown option)
   - Date/Time input fields
   - All "Page # of ##" in table views
- Link missing a text alternative
   - Multichoice dropdown field (multiple options) the close option has no label
   - Connection input fields
   - Table views with blank column names
      - Knack generates a link for sorting asc/desc so when there is no text in table header it gets flagged by SiteImprove
      - Non-code work around: Add text to column names
- Text is clipped when Resized
   - Connection fields with "Select" as default
   - Modal Pop-up titles
   - This is because it is set to `overflow:hidden;`
- Button is missing alternative text
   - Mobile Navigation button
   - Close button in all modal pop-ups

# Notes
## Form field missing a label
For "form field missing labels" in SiteImprove, all the input fields do have labels. 
However, SiteImprove specifies the following:
>A label may already be visible on the page — **but to be accessible, that label needs to be associated with the form element in the HTML.** This helps visitors using screen readers to understand what information is required, while also making it easier for speech-input users to control the form element.

The JS code does not address this by associating with the form element currently. Rather it specifies a generic "Input Date" and "Input Time" for those input fields. It is the same for multichoice dropdown fields as well set to a generic "Select" label for `aria-label`. Ideally we would want it associated to the label that is already visible on the screen.

## Text is clipped when Resized
The way it is resolved is by setting it from `overflow:hidden;` to `overflow:visible` in the CSS file specially for Connection fields and Modal pop-up titles. This part would need testing of long connection names and long modal pop-up titles.

## What is not covered
 - All icons in Rich Text input
    - Non-Code workaround - replace with Paragraph Text input
 - Interactive element does not meet minimum size nor spacing
    - Pie Chart report views with legend buttons.