### PR TITLE
Urban Forestry: Auto Submit, Edit Modals, Breadcrumb, & Back Link update for Urban Forestry Requests

### DIFF
--- a/code/urban-forestry/urban-forestry.css
+++ b/code/urban-forestry/urban-forestry.css
@@ -157,6 +157,10 @@ img.knHeader__logo-image {
 #kn-scene_133 .kn-back-link {
   display: none;
 }
+/*View Request Details Page*/
+#kn-scene_149 .kn-back-link {
+  display: none;
+}
 
 /*******************************************/
 /************ Wrap Table Headers ***********/

--- a/code/urban-forestry/urban-forestry.js
+++ b/code/urban-forestry/urban-forestry.js
@@ -102,6 +102,7 @@ const BREADCRUMB_SCENES = [
   // Urban Forestry Request
   'scene_113', // Add Images page
   'scene_133', // Request Confirmation page
+  'scene_149', // View Request Details page
 ];
 
 BREADCRUMB_SCENES.forEach(scene => {
@@ -156,4 +157,19 @@ $(document).on("knack-view-render.view_161", function (event, scene) {
   var pw = generatePassword();
   $('input[name$="password"]').val(pw);
   $('input[name$="password_confirmation"]').val(pw);
+});
+
+/***********************************/
+/*** Automatically Submit a Form ***/
+/***********************************/
+/* Disconnect UFR Attachment from Work Ticket - Urban Forestry Request Details page */
+$(document).on('knack-scene-render.scene_145', function(event, scene) {
+    $('button[type=submit]').submit();
+});
+
+/*************************************************************************************/
+/** Disable the ability to Click/Touch outside a Modal Page (accidentally close it) **/
+/*************************************************************************************/
+$(document).on("knack-scene-render.any", function (event, scene) {
+  $(".kn-modal-bg").off("click");
 });


### PR DESCRIPTION
Work performed for [28151](https://github.com/cityofaustin/atd-data-tech/issues/28151) & [28150](https://github.com/cityofaustin/atd-data-tech/issues/28150)

Enhancements for Urban Forestry Request module include updated breadcrumb disabling, back link disabling, prevent accidental modal closure for forms, and auto submit the disconnect Work Ticket form so the extra click isnt needed.