### PR TITLE
AMD Data Tracker - Update Attachment Field Name Code

### DIFF
--- a/code/data-tracker/data-tracker.css
+++ b/code/data-tracker/data-tracker.css
@@ -130,7 +130,10 @@ a.small-button {
     font-size: 22px;
   }
 }
-        
+
+/***************************************/
+/************ Miscellaneous ************/
+/***************************************/    
 .kn-link-disabled span {
   color: #bdbebf !important;
 }
@@ -140,27 +143,21 @@ a.small-button {
 }
 
 .button-padding {
-  padding-left: 20%
+  padding-left: 20%;
 }
-
-/* hide attachment type column (field contents are extracted via JS */
-div.view_2107 .field_2403 { display: none; }
-div.view_2108 .field_2403 { display: none; }
-
-/* hide attachment type columns (in Traffic Counts), field contents extracted via JS */
-div.view_2357 .field_3174 { display: none; }
-div.view_2486 .field_3174 { display: none; }
-
-/* hide attachment type columns (in Manage Requests under Traffic Counts), field contents extracted via JS */
-div.view_2491 .field_3174 { display: none; }
-
-/* hide attachment type columns (in Request Status under Traffic Counts), field contents extracted via JS */
-div.view_2465 .field_3174 { display: none; }
 
 .hiddenFormField {
   visibility: hidden;
   height: 0px;
   margin-bottom: 0 !important;
+}
+
+/* Wraps text in Signals Details > Service Requests - Details field */
+view_1704 td.field_1446 > * {
+  overflow: auto;
+  overflow-wrap: break-word;
+  width: 60px;
+  max-height: 100px;
 }
 
 /***************************/
@@ -291,14 +288,6 @@ div.view_2465 .field_3174 { display: none; }
     margin-top: -2em;
   }
 
-}
-
-/* Wraps text in Signals Details>Service Requests - Details field */
-view_1704 td.field_1446 > * {
-  overflow: auto;
-  overflow-wrap: break-word;
-  width: 60px;
-  max-height: 100px;
 }
 
 /*********************************************/

--- a/code/data-tracker/data-tracker.js
+++ b/code/data-tracker/data-tracker.js
@@ -133,59 +133,42 @@ var colorMapOne = {
   "FINAL REVIEW": { background_color: "#4daf4a", color: "#fff" },
 };
 
-$(document).on("knack-view-render.view_2107", function (event, page) {
-  //  replace attachment filename with attachment type
-  //  find each attachment cell
-  $("td.field_2405").each(function () {
-    //  find each attachment link within the cell
-    $(this)
-      .find("a")
-      .each(function (index) {
-        var attachmentType = "";
+/********************************************************/
+/*** Relabel Attachment Links in Tables to Name Field ***/
+/********************************************************/
+//  replace attachment file name with name field. hide_name to hide nameField from table
+function replaceAttachmentFilenameWithNameField(fileFieldId, nameFieldId, hide_name = true) {
+  // find each attachment cell
+  $("td." + fileFieldId).each(function() {
+    // find each attachment link within the cell
+    $(this).find("span").children("span").each(function() {
+      let attachmentType = "View";
+      let fileRecordId = $(this).context.id;
 
-        //  search the neighboring field (attachmenty type) and retrieve the corresponding type
-        $(this)
-          .closest("tr")
-          .children("td.field_2403")
-          .find("span")
-          .children("span")
-          .each(function (index2) {
-            if (index == index2) {
-              attachmentType = $(this).text();
-            }
-          });
-
-        //  update link contents
-        $(this).html(attachmentType);
-      });
+      // if neighboring field exists on same table, retrieve the corresponding type
+      $(this).closest("tr").children("td." + nameFieldId)
+        .find("span")
+        .children("span")
+        .each(function() {
+          let nameRecordId = $(this).context.id;
+          if (fileRecordId == nameRecordId) {
+            attachmentType = $(this).text();
+          }
+        });
+      //  update link contents
+      $(this).find("a").html(attachmentType);
+    });
   });
-});
 
-$(document).on("knack-view-render.view_2108", function (event, page) {
-  //  replace attachment filename with attachment type
-  //  find each attachment cell
-  $("td.field_2405").each(function () {
-    //  find each attachment link within the cell
-    $(this)
-      .find("a")
-      .each(function (index) {
-        var attachmentType = "";
+  // hides the name field ID based on third parameter. Default true.
+  if (hide_name){
+    $("td." + nameFieldId).hide();
+    $("th." + nameFieldId).hide();
+  }
+}
 
-        //  search the neighboring field (attachmenty type) and retrieve the corresponding type
-        $(this)
-          .closest("tr")
-          .children("td.field_2403")
-          .find("span")
-          .children("span")
-          .each(function (index2) {
-            if (index == index2) {
-              attachmentType = $(this).text();
-            }
-          });
-        //  update link contents
-        $(this).html(attachmentType);
-      });
-  });
+$(document).on("knack-view-render.any", function (event, view, data) {
+  replaceAttachmentFilenameWithNameField("field_3176", "field_3174"); // Traffic Count Attachments
 });
 
 //  replace 'Quantity' label with UOM of measure by parsing the select value contents
@@ -271,125 +254,6 @@ $(document).on("knack-view-render.view_1206", function () {
 ////////////////////////////////////////
 // End non-digit character removal /////
 ////////////////////////////////////////
-
-$(document).on("knack-view-render.view_2357", function (event, page) {
-  //  now with minor changes, used for traffic count attachments field
-  //  this one affects the table that those with editing priviledges see
-  //  replace attachment filename with attachment type
-  //  find each attachment cell
-  $("td.field_3176").each(function () {
-    //  find each attachment link within the cell
-    $(this)
-      .find("a")
-      .each(function (index) {
-        var attachmentType = "";
-
-        //  search the neighboring field (attachmenty type) and retrieve the corresponding type
-        $(this)
-          .closest("tr")
-          .children("td.field_3174")
-          .find("span")
-          .children("span")
-          .each(function (index2) {
-            if (index == index2) {
-              attachmentType = $(this).text();
-            }
-          });
-
-        //  update link contents
-        // and add a line break to make it consistent with the box next to it (BH)
-        $(this).html(attachmentType + "<br>");
-      });
-  });
-});
-
-$(document).on("knack-view-render.view_2486", function (event, page) {
-  //  now with minor changes, used for traffic count attachments field
-  //  this one affects the table that those without editing priviledges see
-  //  replace attachment filename with attachment type
-  //  find each attachment cell
-  $("td.field_3176").each(function () {
-    //  find each attachment link within the cell
-    $(this)
-      .find("a")
-      .each(function (index) {
-        var attachmentType = "";
-        //  search the neighboring field (attachmenty type) and retrieve the corresponding type
-        $(this)
-          .closest("tr")
-          .children("td.field_3174")
-          .find("span")
-          .children("span")
-          .each(function (index2) {
-            if (index == index2) {
-              attachmentType = $(this).text();
-            }
-          });
-
-        //  update link contents
-        // and add a line break to make it consistent with the box next to it (BH)
-        $(this).html(attachmentType + "<br>");
-      });
-  });
-});
-
-$(document).on("knack-view-render.view_2491", function (event, page) {
-  // Another copy of the find and replace attachment types script, this one for the manage requests
-  // page
-  $("td.field_3176").each(function () {
-    //  find each attachment link within the cell
-    $(this)
-      .find("a")
-      .each(function (index) {
-        var attachmentType = "";
-
-        //  search the neighboring field (attachmenty type) and retrieve the corresponding type
-        $(this)
-          .closest("tr")
-          .children("td.field_3174")
-          .find("span")
-          .children("span")
-          .each(function (index2) {
-            if (index == index2) {
-              attachmentType = $(this).text();
-            }
-          });
-
-        //  update link contents
-        // and add a line break to make it consistent with the box next to it (BH)
-        $(this).html(attachmentType + "<br>");
-      });
-  });
-});
-
-$(document).on("knack-view-render.view_2465", function (event, page) {
-  // Another copy of the find and replace attachment types script.  This one is used
-  // on the Request Status page under Traffic Counts.
-  $("td.field_3176").each(function () {
-    //  find each attachment link within the cell
-    $(this)
-      .find("a")
-      .each(function (index) {
-        var attachmentType = "";
-
-        //  search the neighboring field (attachmenty type) and retrieve the corresponding type
-        $(this)
-          .closest("tr")
-          .children("td.field_3174")
-          .find("span")
-          .children("span")
-          .each(function (index2) {
-            if (index == index2) {
-              attachmentType = $(this).text();
-            }
-          });
-
-        //  update link contents
-        // and add a line break to make it consistent with the box next to it (BH)
-        $(this).html(attachmentType + "<br>");
-      });
-  });
-});
 
 /////////////////////////////////////////////////////////////
 //// Change field color of inventory request statuses ///////


### PR DESCRIPTION
This is for https://github.com/cityofaustin/atd-data-tech/issues/28627 

This was discovered from copying the table for https://github.com/cityofaustin/atd-data-tech/issues/28456.

The new code is currently used for MSP. See Gitbook on [Relabel Attachments Code](https://atd-dts.gitbook.io/atd-knack-operations/knack-code/looks/relabel-attachment-links) and how it works.

Currently this will only impact Traffic Count records tables with two columns (child `traffic_count_attachment` Files and corresponding child `traffic_count_attachment` File Types field).
## User sees this
<img width="500" alt="image" src="https://github.com/user-attachments/assets/618bc762-d6d4-4ae6-adc0-9e433d151cef" />

## Builder sees this 
<img width="500" alt="image" src="https://github.com/user-attachments/assets/93b49f64-171d-4451-a1a1-96437bb79543" />

# Why is this happening
The old code works by replacing the children attachment names with a specific children field. Talking to Christina, this is useful for data collection team to see what attachments they are viewing and to not overcrowd the table. When copying one of the table for contractor use, it was discovered that the traffic count tables are using this code.

Furthermore, half of the old code is referencing fields and views that no longer exist in AMD Data Tracker and was done by copy pasting the same code snippet 5-6 times for each view, making it hard to maintain. The attachment name code was last updated 6 years ago.

# What Changed (Code)
## JS
- Removed code snippets of attachment name code where views do not exist and fields do not exist
- The previous code worked by specifying the view ID. The way this one works is that it will apply **if both the Traffic Count Attachment File and Traffic Count Attachment Name column exist next to each other** on any table view, so no view ID needed to be specified
- Added comment block "Relabel Attachment Links in Tables to Name Field" to make it clear what the function of the code snippet is for
## CSS
- Removed CSS on hiding column names on specific view IDs, as that will be covered in the JS instead using the `hide_name` parameter in `function replaceAttachmentFilenameWithNameField(fileFieldId, nameFieldId, hide_name = true)`
- Added new comment block called `Miscellaneous Code` to separate it from `Mobile Styling` code
- Added missing semicolon for `button-padding` in CSS
- Moved CSS code 296-303 to the Miscellaneous Code section to keep it organized and separated from `Step Indicator` code

# What changed (Builder)
- The tables using the old code were all set to Commas instead of New Line and the old code compensated it by adding `<br>` which lead to attachment names starting with a comma (for example `SPD` turned into `,SPD`). I have changed them to new lines
- I renamed the column "Attachment Type" to "Attachment Type (Hidden)" similar to SMD and MSP. This will make it clear to builders that this specific column is hidden from the user as a result of the code.

## From [#28627](https://github.com/cityofaustin/atd-data-tech/issues/28627)
You may click on the view IDs to see what it looks like on the builder side and see how it looks on live view.
> - Check the following views to swap from commas to new line: [Knack Explorer](https://knack-explorer.netlify.app/5815f29f7f7252cc2ca91c4f)
>    - <s>view_2107</s> (cannot find in Knack explorer)
>    - <s>view_2108</s> (cannot find in Knack explorer)
>    - [x]  [view_2357](https://builder.knack.com/atd/amd/pages/scene_924)
>    - <s>view_2486</s> Deleted dupe table see [Ability to add location coordinate data to Data Collection Requests #28456](https://github.com/cityofaustin/atd-data-tech/issues/28456) as it existed in scene_924
>    - [x]  [view_2491](https://builder.knack.com/atd/amd/pages/scene_988/views/view_2491/table)
>    - [x]  [view_2465](https://builder.knack.com/atd/amd/pages/scene_977/views/view_2465/table)
> - Renamed `Attachment Type` label to `Attachment Type (Hidden)` on Table columns above to make it clear on backend that this column is hidden
> - view_2107 and view_2108 applied this code to field_2405 and field_2403. These fields do not exist according to Knack Explorer
> - New views included that this code was previously not applying:
>   - [view_4123](https://builder.knack.com/atd/amd/pages/scene_988/views/view_4123/table/columns/15) (updated from comma to new line)

<img alt="Image" width="1401" height="592" src="https://private-user-images.githubusercontent.com/31259724/596854432-fc2969ae-1926-4203-ae92-de29e375d6b3.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3Nzk4MDcxMzIsIm5iZiI6MTc3OTgwNjgzMiwicGF0aCI6Ii8zMTI1OTcyNC81OTY4NTQ0MzItZmMyOTY5YWUtMTkyNi00MjAzLWFlOTItZGUyOWUzNzVkNmIzLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNjA1MjYlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjYwNTI2VDE0NDcxMlomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTIzMGIxYmUzOTBhOTI5NzhhYTE0ZjZjZWI5OGVjMTMzNTJkYjA1NmJiZDVkYTBkMmU0Y2YxNTcwY2ExYjc0MjUmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JnJlc3BvbnNlLWNvbnRlbnQtdHlwZT1pbWFnZSUyRnBuZyJ9.Kdg0ctbVTTp4wMM9fhdk8Rdjspkm1n9MnGQKfNBlufg">