### PR TITLE
AMD Data Tracker - Easy Paste Location Coordinates using JS

### DIFF
--- a/code/data-tracker/data-tracker.js
+++ b/code/data-tracker/data-tracker.js
@@ -1171,3 +1171,31 @@ BREADCRUMB_SCENES.forEach(scene => {
 $(document).on("knack-scene-render.any", function (event, scene) {
   $(".kn-modal-bg").off("click");
 });
+
+/*******************************************/
+/*** Lat/Long Coordinate Clipboard Paste ***/
+/*******************************************/
+// Paste Coordinates from clipboard
+async function pasteCoordinates(latitude,longitude) {
+    try {
+      const latField = document.querySelector(`input[name="${latitude}"]`);
+      const lngField = document.querySelector(`input[name="${longitude}"]`);
+      const text = await navigator.clipboard.readText();
+      const coords = text.split(',').map(parseFloat);
+      if(coords.length == 2 && !Number.isNaN(coords)) {
+          lngField.value = - Math.max(...coords.map(Math.abs));
+          latField.value = Math.min(...coords.map(Math.abs));
+      }
+      // Run if address coordinate field exists
+      pasteCoordinates("latitude","longitude");
+    } catch (err) {
+        console.error(`Clipboard read failed:`, err);
+    }
+}
+
+$(document).on('knack-view-render.view_4966', function () {
+  const lat = document.querySelector('input[name="field_5331"]');
+  const long = document.querySelector('input[name="field_5330"]');
+  lat.addEventListener('paste',     () => {pasteCoordinates("field_5331","field_5330")});
+  long.addEventListener('paste',     () => {pasteCoordinates("field_5331","field_5330")});
+});

--- a/code/data-tracker/data-tracker.js
+++ b/code/data-tracker/data-tracker.js
@@ -1182,9 +1182,9 @@ async function pasteCoordinates(latitude,longitude) {
       const lngField = document.querySelector(`input[name="${longitude}"]`);
       const text = await navigator.clipboard.readText();
       const coords = text.split(',').map(parseFloat);
-      if(coords.length == 2 && !Number.isNaN(coords)) {
-          lngField.value = - Math.max(...coords.map(Math.abs));
-          latField.value = Math.min(...coords.map(Math.abs));
+      if(coords.length == 2 && coords) {
+        lngField.value = Math.min(...coords);
+        latField.value = Math.max(...coords);
       }
       // Run if address coordinate field exists
       pasteCoordinates("latitude","longitude");


### PR DESCRIPTION
This is for [#28629](https://github.com/cityofaustin/atd-data-tech/issues/28629) - Improvements to Populating and Visualizing Location Coordinates

Builder Link: https://builder.knack.com/atd/amd/pages/scene_2004/views/view_4966/form


## Test Example
Live Test Example: https://atd.knack.com/amd#traffic-count-traffic-data-requests/traffic-count-details/6a0f7593939741cf76ef1292/

https://github.com/user-attachments/assets/5d420e6d-6367-4193-bb08-2eaff5e8aaf4


NOTE: You will need the "System Administration" role to see the form
NOTE 2: You will need to add your email in page rule as well to see menu: https://builder.knack.com/atd/amd/pages/scene_926/rules

1. Go to "Add Location Details" button on top of the page. Should show modal pop-up
2. Sign-In to AGOL
<img width="382"  alt="image" src="https://github.com/user-attachments/assets/d56270ea-d1d7-4fa3-a78e-38fff7ee1c12" />

3. Use the copy coordinates on the map in AGOL (yes, it requires 4 clicks currently)
<img width="481" alt="image" src="https://github.com/user-attachments/assets/3bf636fa-2e7b-4360-b353-7d4331782474" />


5. Paste into any of the input using Keyboard shortcut Ctrl + V (or Mac Cmd +v) on either Inputs
   - **Your browser might ask to allow reading Clipboard data as a pop-up. Click "Allow"**
<img width="446"  alt="image" src="https://github.com/user-attachments/assets/d1627f5c-b0bd-4428-bdeb-16b808947607" />

## Why are we doing this
- Saves formatting time for user
- Reduces changes for data input errors (Assumes long is highest _absolute_ number (-97) and lat is lowest number in the Austin area)
- Contractors need coordinate X and Y as a URL parameter for viewing location details with **aerial Nearmap imagery** in the future. So using Knack built in map view would not work. Future build with geo.

## Why both these fields listed twice
<img width="447" alt="image" src="https://github.com/user-attachments/assets/7ba74686-ff4c-4de2-9fa2-5630d2b1db61" />

- The first one is a Number fields used to create a URL parameter using a Text Formula for contractors
- The second one is an "Address" field. This could be used for a Map search view.
- Currently when Knack does address, on the front-end the Address field does not show lat/longs
   - When exporting the records or pulling it via API table it does show coordinates 
   - There is no Text Formula/Equation that can retrieve the Lat/Long coordinates in an address field as far as I know. Only through export button or API table.