### PR TITLE
Updated big button url for FAQ to HELP

### DIFF
--- a/code/shared-mobility/shared-mobility-smrt.js
+++ b/code/shared-mobility/shared-mobility-smrt.js
@@ -83,7 +83,7 @@ $(document).on("knack-view-render.view_627", function(event, page) {
 });
 // create large Help button on the Customer RPP Portal page
 $(document).on("knack-view-render.view_628", function(event, page) {
-  bigButton("faq", "view_628", `${APP_URL}#faq/`, "info-circle", "Help");
+  bigButton("faq", "view_628", `${APP_URL}#help/`, "info-circle", "Help");
 });
 // create large About the Program button on the Customer RPP Portal page
 $(document).on("knack-view-render.view_629", function(event, page) {


### PR DESCRIPTION
Updated big button "FAQ" to no longer connect to a blank FAQ page, but the actual customer Help page to access help guides.

Related to #29099 
- [Portal page](https://atd.knack.com/smrt#portal/)
