### PR TITLE
TDS Portal: Privacy Policy Footer on Public pages & remove Available Services big button

### DIFF
--- a/code/transportation-development-services/tds.css
+++ b/code/transportation-development-services/tds.css
@@ -1392,3 +1392,27 @@ img.knHeader__logo-image {
   margin-left: 10px;
 }
 
+/*************************************/
+/**** COA FOOTER - Simple Version ****/
+/*************************************/
+#coa-footer {
+  text-align: center;
+  padding: 24px 16px;
+  margin-top: 32px;
+  font-size: 13px;
+  color: #888;
+  border-top: 1px solid #e5e5e5;
+}
+
+#coa-footer img {
+  display: block;
+  margin: 0 auto 12px;
+  max-width: 80px;
+  height: auto;
+}
+
+#coa-footer a {
+  color: #555;
+  text-decoration: underline;
+}
+

--- a/code/transportation-development-services/tds.js
+++ b/code/transportation-development-services/tds.js
@@ -121,12 +121,6 @@ $(document).on("knack-view-render.view_1272", function(event, page) {
   bigButton("sep", "view_1272", `${APP_URL}#sif-encumbrance-projects/`, "certificate", "SIF Encumbrance Projects");
 });
 
-
-// create large Available Services button on the Customer Portal Home page
-$(document).on("knack-view-render.view_1429", function(event, page) {
-  bigButton("available-services", "view_1429", `${APP_URL}#customer-portal/services/`, "list-ul", "Available Services");
-});
-
 // create large TDS Link button on the Customer Portal Home page
 $(document).on("knack-view-render.view_1432", function(event, page) {
   bigButton("tds-link", "view_1432", "https://www.austintexas.gov/transportation-public-works/divisions/transportation-development-services", "bank", "TDS Division Home", true);
@@ -1436,3 +1430,81 @@ $(document).on("knack-view-render.view_1591", function (event, scene) {
   $('input[name$="password_confirmation"]').val(pw);
 });
 
+/*************************************/
+/**** COA FOOTER - Simple Version ****/
+/*************************************/
+  // Dynamically injects a branded footer into specific customer-facing standard Knack pages only.
+  // Use this version for apps where displaying the footer on modal windows is not required.
+  // Caution: Navigating from a standard page > modal page > and then to a new standard page from a menu view on that modal page may cause footer ghosting/duplication to occur
+  // Best Practice: Modals are okay as long as a user isnt required to navigate with the modal. Instead the user should navigate via the top nav or a standard page
+  //
+  // To display the footer on a new page: append its URL hash and scene ID comment to the footerHashes array below.
+(function() {
+
+  // List of exact URL hashes that should display the footer. Only exact matches are used — child pages (e.g. #customer/my-projects/) are automatically excluded.
+  const footerHashes = [
+    '#customer-portal/',                                             // scene_258
+    '#customer-portal/access-case/61e9958f57ad0100231d515e/',        // scene_480
+    '#services/traffic-impact-analysis-determination/',              // scene_581
+    '#services/traffic-impact-analysis-compliance/',                 // scene_582
+    '#services/traffic-impact-analysis/',                            // scene_583
+    '#services/neighborhood-traffic-analysis/',                      // scene_584
+    '#services/transportation-assessment/',                          // scene_585
+    '#services/zoning-transportation-analysis/',                     // scene_586
+    '#services/street-impact-fee-worksheet/',                        // scene_587
+    '#services/tpw-waiver/',                                         // scene_831
+  ];
+
+  // Our structured Footer HTML consisting of the COA Brand, the Privacy Policy, and any app specific Contact Info
+  // Styling is handled in the Knack CSS file via the #coa-footer selector.
+  const footerHTML = `
+    <div id="coa-footer">
+      <img 
+        src="https://images.gitbook.com/__img/dpr=2,width=760,onerror=redirect,format=auto,signature=1503205633/https%3A%2F%2Ffiles.gitbook.com%2Fv0%2Fb%2Fgitbook-x-prod.appspot.com%2Fo%2Fspaces%252FCqNGfEc0WO4ar1y6yBB3%252Fuploads%252F94aonme89HIUpHVnpeuK%252FCOA-Logo-Horizontal-Official-RGB.png%3Falt%3Dmedia%26token%3Da9121b5d-9d3c-41d0-9e72-90e25938e553" 
+        alt="City of Austin Footer Logo" 
+      />
+      <a href="https://www.austintexas.gov/page/privacy-policy" target="_blank" rel="noopener noreferrer">
+        Privacy Policy
+      </a>
+    </div>
+  `;
+
+  // Inject footer for standard pages. Runs on initial page load and every time the URL hash changes.
+  function injectFooter() {
+    const hash = window.location.hash;
+
+    // Check if the current hash exactly matches one of our footer pages
+    const shouldShow = footerHashes.some(function(h) { return hash === h; });
+
+    // If we're not on a footer page, remove the footer and exit
+    if (!shouldShow) {
+      $('#coa-footer').remove();
+      return;
+    }
+
+    // Check if the footer is already present in #knack-body
+    if ($('#knack-body #coa-footer').length) return;
+
+    // Poll every 100ms for #knack-body to be available in the DOM as it may not exist immediately after hash change. Exits after 2s.
+    const maxAttempts = 20;
+    let attempts = 0;
+
+    const interval = setInterval(function() {
+      attempts++;
+      if ($('#knack-body').length) {
+        clearInterval(interval);
+        $('#knack-body').append(footerHTML);
+      } else if (attempts >= maxAttempts) {
+        clearInterval(interval);
+        console.warn('COA Footer: #knack-body not found after max attempts');
+      }
+    }, 100);
+  }
+
+  // Run on initial page load
+  $(window).on('load', injectFooter);
+
+  // Run on every hash change (triggered by navigation)
+  $(window).on('hashchange', injectFooter);
+
+})();

--- a/code/transportation-development-services/tds.js
+++ b/code/transportation-development-services/tds.js
@@ -1474,7 +1474,7 @@ $(document).on("knack-view-render.view_1591", function (event, scene) {
     const hash = window.location.hash;
 
     // Check if the current hash exactly matches one of our footer pages
-    const shouldShow = footerHashes.some(function(h) { return hash === h; });
+    const shouldShow = footerHashes.includes(hash);
 
     // If we're not on a footer page, remove the footer and exit
     if (!shouldShow) {


### PR DESCRIPTION
This PR is for the [Privacy Policy Footer](https://github.com/cityofaustin/atd-knack/pull/247) at the bottom of the public TDS pages. This also removes the Available Services big button to ensure the footer shows on service pages per [#29266](https://github.com/cityofaustin/atd-data-tech/issues/29266)

This work is for [#29082](https://github.com/cityofaustin/atd-data-tech/issues/29082) and [#26314](https://github.com/cityofaustin/atd-data-tech/issues/26314)