### PR TITLE
MSP - Add Print button to Certificate and Approval Letter in Operating Authority

### DIFF
--- a/code/mobility-services/mobility-services.js
+++ b/code/mobility-services/mobility-services.js
@@ -269,7 +269,7 @@ const PRINT_MENU_VIEWS = [
 
 PRINT_MENU_VIEWS.forEach(view => {
   $(document).on(`knack-view-render.${view}`, function() {
-  printMenuButton(view);
+    printMenuButton(view);
   });
 });
 

--- a/code/mobility-services/mobility-services.js
+++ b/code/mobility-services/mobility-services.js
@@ -247,7 +247,7 @@ $(document).on("knack-scene-render.any", function (event, view) {
 });
 
 /***************************************/
-/***** Print Menu Button ************/
+/******** Print Menu Button ************/
 /***************************************/
 function printMenuButton(view_id) {
   $("#" + view_id + " .knMenuLink").click(function (e) {
@@ -255,38 +255,22 @@ function printMenuButton(view_id) {
   });
 }
 
-/* Print 3 pages menu view button - Chauffeur Permit*/
-$(document).on("knack-view-render.view_227", function (event, view, data) {
-  // Customer Print
-  printMenuButton("view_227");
-});
+// Print Menu Button Views
+const PRINT_MENU_VIEWS = [
+  'view_227',   // Chauffeur Permit - 3 Pages - Applicant
+  'view_315',   // Chauffeur Permit - 3 Pages - Reviewer
+  'view_228',   // Chauffeur Permit - 4 Pages - Applicant
+  'view_304',   // Chauffeur Permit - 4 Pages - Reviewer
+  'view_1148',  // Operating Authority - Notary - Applicant
+  'view_1389',  // Operating Authority - Notary - Reviewer
+  'view_1546',  // Operating Authority - Approval Letter
+  'view_1547',  // Operating Authority - Certificate Letter
+];
 
-$(document).on("knack-view-render.view_315", function (event, view, data) {
-  // Reviewer Print
-  printMenuButton("view_315");
-});
-
-/* Print 4 pages menu view button - Chauffeur Permit*/
-$(document).on("knack-view-render.view_228", function (event, view, data) {
-  // Customer Print
-  printMenuButton("view_228");
-});
-
-$(document).on("knack-view-render.view_304", function (event, view, data) {
-  // Reviewer Print
-  printMenuButton("view_304");
-});
-
-/* Print Operating Authority Notary Page - Applicant */
-$(document).on("knack-view-render.view_1148", function (event, view, data) {
-  // Primary Holder Print
-  printMenuButton("view_1148");
-});
-
-/* Print Operating Authority Notary Page - Reviewer */
-$(document).on("knack-view-render.view_1389", function (event, view, data) {
-  // Primary Holder Print
-  printMenuButton("view_1389");
+PRINT_MENU_VIEWS.forEach(view => {
+  $(document).on(`knack-view-render.${view}`, function() {
+  printMenuButton(view);
+  });
 });
 
 /****************************************/


### PR DESCRIPTION
This is for [#29071](https://github.com/cityofaustin/atd-data-tech/issues/29071#issuecomment-4928254550)

> Added visible print menu buttons on certificate and approval letter similar to notary pages used in OA and Chauffeur (view 1546 and view 1547)

<img width="436" height="186" alt="image" src="https://github.com/user-attachments/assets/b06aa172-2e70-4251-9073-4b24c4ba0b2c" />

Test application pages (need "Approver" Role to view)
- [Approval Letter](https://atd.knack.com/mobility-services#manage-applications-operating-authority/review-application-operating-authority/69d7ff1c7330dac2509f54ec/view-approval-letter-certificate/69d7ff1c7330dac2509f54ec/print-approval-letter/69d7ff1c7330dac2509f54ec/)
- [Certificate Letter](https://atd.knack.com/mobility-services#manage-applications-operating-authority/review-application-operating-authority/69d7ff1c7330dac2509f54ec/view-approval-letter-certificate/69d7ff1c7330dac2509f54ec/certificate-letter/69d7ff1c7330dac2509f54ec/)

## Why are we doing this
- Print button visibility for Applicant/Approver
- The print buttons are already used for Chauffeur Notary and Operating Authority Notary pages

## Additional Notes
Due to a large number of print menu buttons in the app, I refactored the code to a `forEach()` loop similar to how we [disable breadcrumb trails](https://app.gitbook.com/o/-LzDQOVGhTudbKRDGpUA/s/-LzNSSXajDFpzOv2IhIv/knack-code/functionality/disable-nav-links).

I'll update the gitbook if this looks good.

Tested it on both existing pages and new pages and print button pages works as expected.