### PR TITLE
Dropping DAPCZ on big buttons.js

### DIFF
--- a/code/right-of-way/right-of-way.js
+++ b/code/right-of-way/right-of-way.js
@@ -166,22 +166,22 @@ $(document).on("knack-view-render.view_1593", function(event, page) {
 
 // create large DAPCZ Agenda button on the DAPCZ Public Portal page
 $(document).on("knack-view-render.view_1505", function(event, page) {
-  bigButton("dapcz-agenda", "view_1505", `${APP_URL}#dapcz-meeting/dapcz-agenda/`, "file-o", "DAPCZ Agenda");
+  bigButton("dapcz-agenda", "view_1505", `${APP_URL}#dapcz-meeting/dapcz-agenda/`, "file-o", "Agenda");
 });
 
 // create large DAPCZ Project List button on the DAPCZ Public Portal page
 $(document).on("knack-view-render.view_1506", function(event, page) {
-  bigButton("dapcz-project-list", "view_1506", `${APP_URL}#dapcz-meeting/dapcz-project-list/`, "list-ul", "DAPCZ Project List");
+  bigButton("dapcz-project-list", "view_1506", `${APP_URL}#dapcz-meeting/dapcz-project-list/`, "list-ul", "Project List");
 });
 
 // create large DAPCZ Links button on the DAPCZ Public Portal page
 $(document).on("knack-view-render.view_1507", function(event, page) {
-  bigButton("dapcz-links", "view_1507", `${APP_URL}#dapcz-meeting/dapcz-links/`, "link", "DAPCZ Links & Resources");
+  bigButton("dapcz-links", "view_1507", `${APP_URL}#dapcz-meeting/dapcz-links/`, "link", "Helpful Links & Resources");
 });
 
 // create large DAPCZ Meeting Schedule button on the DAPCZ Public Portal page
 $(document).on("knack-view-render.view_1508", function(event, page) {
-  bigButton("dapcz-meeting-schedule", "view_1508", `${APP_URL}#dapcz-meeting/dapcz-meeting-schedule`, "calendar", "DAPCZ Meeting Schedule");
+  bigButton("dapcz-meeting-schedule", "view_1508", `${APP_URL}#dapcz-meeting/dapcz-meeting-schedule`, "calendar", "Meeting Access & Schedule");
 });
 
 /********************************************/


### PR DESCRIPTION
Removing DAPCZ on the big buttons to save button real estate

- Update to [PR 287](https://github.com/cityofaustin/atd-knack/pull/287) 

## Before
<img width="582" height="568" alt="image" src="https://github.com/user-attachments/assets/3ec245ae-7653-4d32-b662-73b262ac9d3a" />

## After
<img width="551" height="463" alt="image" src="https://github.com/user-attachments/assets/b2ec20c1-62a1-47a6-8c14-291a7d17b013" />