### PR TITLE
29033 AMD Data Tracker - Refresh Detail View on Form submission

### DIFF
--- a/code/data-tracker/data-tracker.js
+++ b/code/data-tracker/data-tracker.js
@@ -1199,3 +1199,20 @@ $(document).on('knack-view-render.view_4966', function () {
   lat.addEventListener('paste',     () => {pasteCoordinates("field_5331","field_5330")});
   long.addEventListener('paste',     () => {pasteCoordinates("field_5331","field_5330")});
 });
+
+/****************************************/
+/******* Refresh View on Submit  ********/
+/****************************************/
+// A function to refresh a specified view
+function refreshView(viewKey) {
+  Knack.views[viewKey].model.fetch();
+  setTimeout(() => {
+    Knack.views[viewKey].render();
+    Knack.views[viewKey].postRender(); 
+  }, 2000);
+}
+
+// When request complete form is submitted, refresh Traffic Count Details view
+$(document).on('knack-form-submit.view_5026', function (event, view, data) {
+  refreshView('view_2359');
+});


### PR DESCRIPTION
This is for https://github.com/cityofaustin/atd-data-tech/issues/29033

Can Test record: https://atd.knack.com/amd#traffic-count-traffic-data-requests/traffic-count-details/6a0f7593939741cf76ef1292/

<img width="1599" height="602" alt="image" src="https://github.com/user-attachments/assets/fd79a68d-8313-4fb9-afa8-1eb758a8b3e7" />

## Why are we doing this
- Updated the Detail view status from Submitted to Complete
- Saves additional button click navigation

Gitbook doc: https://app.gitbook.com/o/-LzDQOVGhTudbKRDGpUA/s/-LzNSSXajDFpzOv2IhIv/knack-code/functionality/refresh-view-on-record-events

## Additional Notes
- This form is only visible when Status is Submitted using page rules
- The Status is changes using conditional rules